### PR TITLE
Compile within single slice only

### DIFF
--- a/dist/args.d.ts
+++ b/dist/args.d.ts
@@ -1,6 +1,6 @@
 export interface Args {
     path: string;
-    target: string;
+    dest: string;
     watch: Boolean;
     sri: string[] | null;
 }

--- a/dist/args.d.ts
+++ b/dist/args.d.ts
@@ -1,4 +1,5 @@
 export interface Args {
+    path: string;
     watch: Boolean;
     sri: string[] | null;
 }

--- a/dist/args.d.ts
+++ b/dist/args.d.ts
@@ -1,5 +1,6 @@
 export interface Args {
     path: string;
+    target: string;
     watch: Boolean;
     sri: string[] | null;
 }

--- a/dist/args.js
+++ b/dist/args.js
@@ -6,6 +6,7 @@ export const parseArgs = (args) => {
     });
     return {
         path: result["path"],
+        target: result["target"],
         watch: result.hasOwnProperty("watch"),
         sri: result["sri"]?.split(","),
     };

--- a/dist/args.js
+++ b/dist/args.js
@@ -5,6 +5,7 @@ export const parseArgs = (args) => {
         result[key] = value;
     });
     return {
+        path: result["path"],
         watch: result.hasOwnProperty("watch"),
         sri: result["sri"]?.split(","),
     };

--- a/dist/args.js
+++ b/dist/args.js
@@ -6,7 +6,7 @@ export const parseArgs = (args) => {
     });
     return {
         path: result["path"],
-        target: result["target"],
+        dest: result["dest"],
         watch: result.hasOwnProperty("watch"),
         sri: result["sri"]?.split(","),
     };

--- a/dist/esbuild-plugin.d.ts
+++ b/dist/esbuild-plugin.d.ts
@@ -1,12 +1,11 @@
 import { Plugin } from "esbuild";
 export interface PluginOptions {
     root: string;
-    publicDir: string;
     destDir: string;
     manifestPath: string;
     sriAlgorithms: Array<string>;
     hash: boolean;
 }
-export declare const defaults: Pick<PluginOptions, "root" | "publicDir" | "destDir" | "manifestPath" | "sriAlgorithms" | "hash">;
+export declare const defaults: Pick<PluginOptions, "root" | "destDir" | "manifestPath" | "sriAlgorithms" | "hash">;
 declare const hanamiEsbuild: (options?: PluginOptions) => Plugin;
 export default hanamiEsbuild;

--- a/dist/esbuild-plugin.d.ts
+++ b/dist/esbuild-plugin.d.ts
@@ -1,6 +1,7 @@
 import { Plugin } from "esbuild";
 export interface PluginOptions {
     root: string;
+    baseDir: string;
     destDir: string;
     sriAlgorithms: Array<string>;
     hash: boolean;

--- a/dist/esbuild-plugin.d.ts
+++ b/dist/esbuild-plugin.d.ts
@@ -1,7 +1,7 @@
 import { Plugin } from "esbuild";
 export interface PluginOptions {
     root: string;
-    baseDir: string;
+    sourceDir: string;
     destDir: string;
     sriAlgorithms: Array<string>;
     hash: boolean;

--- a/dist/esbuild-plugin.d.ts
+++ b/dist/esbuild-plugin.d.ts
@@ -2,10 +2,9 @@ import { Plugin } from "esbuild";
 export interface PluginOptions {
     root: string;
     destDir: string;
-    manifestPath: string;
     sriAlgorithms: Array<string>;
     hash: boolean;
 }
-export declare const defaults: Pick<PluginOptions, "root" | "destDir" | "manifestPath" | "sriAlgorithms" | "hash">;
-declare const hanamiEsbuild: (options?: PluginOptions) => Plugin;
+export declare const defaults: Pick<PluginOptions, "root" | "sriAlgorithms" | "hash">;
+declare const hanamiEsbuild: (options: PluginOptions) => Plugin;
 export default hanamiEsbuild;

--- a/dist/esbuild-plugin.d.ts
+++ b/dist/esbuild-plugin.d.ts
@@ -6,6 +6,6 @@ export interface PluginOptions {
     sriAlgorithms: Array<string>;
     hash: boolean;
 }
-export declare const defaults: Pick<PluginOptions, "root" | "sriAlgorithms" | "hash">;
+export declare const defaults: Pick<PluginOptions, "sriAlgorithms" | "hash">;
 declare const hanamiEsbuild: (options: PluginOptions) => Plugin;
 export default hanamiEsbuild;

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -147,7 +147,7 @@ const hanamiEsbuild = (options) => {
                     }
                     const destinationUrl = calulateDestinationUrl(copiedAsset[1]);
                     // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
-                    var sourceUrl = copiedAsset[0].replace(path.join(options.root, options.baseDir, "assets") + "/", "");
+                    var sourceUrl = copiedAsset[0].replace(path.join(options.root, options.sourceDir, "assets") + "/", "");
                     // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
                     sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
                     assetsManifest[sourceUrl] = prepareAsset(copiedAsset[1], destinationUrl);

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -6,6 +6,7 @@ export const defaults = {
     sriAlgorithms: [],
     hash: true,
 };
+const assetsDirName = "assets";
 const hanamiEsbuild = (options) => {
     return {
         name: "hanami-esbuild",
@@ -147,7 +148,7 @@ const hanamiEsbuild = (options) => {
                     }
                     const destinationUrl = calulateDestinationUrl(copiedAsset[1]);
                     // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
-                    var sourceUrl = copiedAsset[0].replace(path.join(options.root, options.sourceDir, "assets") + "/", "");
+                    var sourceUrl = copiedAsset[0].replace(path.join(options.root, options.sourceDir, assetsDirName) + "/", "");
                     // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
                     sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
                     assetsManifest[sourceUrl] = prepareAsset(copiedAsset[1], destinationUrl);

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -3,7 +3,6 @@ import path from "path";
 import crypto from "node:crypto";
 const URL_SEPARATOR = "/";
 export const defaults = {
-    root: "",
     sriAlgorithms: [],
     hash: true,
 };
@@ -12,7 +11,6 @@ const hanamiEsbuild = (options) => {
         name: "hanami-esbuild",
         setup(build) {
             build.initialOptions.metafile = true;
-            options.root = options.root || process.cwd(); // TODO: can't this always be passed in?
             const manifestPath = path.join(options.root, options.destDir, "assets.json");
             const externalDirs = build.initialOptions.external || [];
             build.onEnd(async (result) => {

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -4,18 +4,16 @@ import crypto from "node:crypto";
 const URL_SEPARATOR = "/";
 export const defaults = {
     root: "",
-    destDir: path.join("public", "assets"),
-    manifestPath: path.join("public", "assets.json"),
     sriAlgorithms: [],
     hash: true,
 };
-const hanamiEsbuild = (options = { ...defaults }) => {
+const hanamiEsbuild = (options) => {
     return {
         name: "hanami-esbuild",
         setup(build) {
             build.initialOptions.metafile = true;
             options.root = options.root || process.cwd();
-            const manifest = path.join(options.root, options.manifestPath);
+            const manifestPath = path.join(options.root, options.destDir, "assets.json");
             const externalDirs = build.initialOptions.external || [];
             build.onEnd(async (result) => {
                 const outputs = result.metafile?.outputs;
@@ -127,7 +125,7 @@ const hanamiEsbuild = (options = { ...defaults }) => {
                     assetsManifest[sourceUrl] = asset;
                 }
                 // Write assets manifest to the destination directory
-                await fs.writeJson(manifest, assetsManifest, { spaces: 2 });
+                await fs.writeJson(manifestPath, assetsManifest, { spaces: 2 });
             });
         },
     };

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -131,11 +131,12 @@ const hanamiEsbuild = (options) => {
                     return asset;
                 }
                 // Process entrypoints
+                const fileHashRegexp = /(-[A-Z0-9]{8})(\.\S+)$/;
                 for (const compiledEntryPoint in compiledEntryPoints) {
                     // Convert "public/assets/app-2TLUHCQ6.js" to "app.js"
                     let sourceUrl = compiledEntryPoint
                         .replace(options.destDir + "/", "")
-                        .replace(/(-[A-Z0-9]{8})(\.\S+)$/, "$2");
+                        .replace(fileHashRegexp, "$2");
                     const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
                     assetsManifest[sourceUrl] = prepareAsset(compiledEntryPoint, destinationUrl);
                 }

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -4,7 +4,6 @@ import crypto from "node:crypto";
 const URL_SEPARATOR = "/";
 export const defaults = {
     root: "",
-    publicDir: "public",
     destDir: path.join("public", "assets"),
     manifestPath: path.join("public", "assets.json"),
     sriAlgorithms: [],

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -129,12 +129,12 @@ const hanamiEsbuild = (options) => {
                 externalDirs.forEach((pattern) => {
                     copiedAssets.push(...processAssetDirectory(pattern, compiledEntryPoints, options));
                 });
-                function prepareAsset(destinationUrl) {
+                function prepareAsset(assetPath, destinationUrl) {
                     var asset = { url: destinationUrl };
                     if (options.sriAlgorithms.length > 0) {
                         asset.sri = [];
                         for (const algorithm of options.sriAlgorithms) {
-                            const subresourceIntegrity = calculateSubresourceIntegrity(algorithm, destinationUrl);
+                            const subresourceIntegrity = calculateSubresourceIntegrity(algorithm, path.join(options.root, assetPath));
                             asset.sri.push(subresourceIntegrity);
                         }
                     }
@@ -144,7 +144,7 @@ const hanamiEsbuild = (options) => {
                 for (const compiledEntryPoint in compiledEntryPoints) {
                     const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
                     const sourceUrl = compiledEntryPoints[compiledEntryPoint].replace(`${options.baseDir}/assets/js/`, "");
-                    assetsManifest[sourceUrl] = prepareAsset(destinationUrl);
+                    assetsManifest[sourceUrl] = prepareAsset(compiledEntryPoint, destinationUrl);
                 }
                 // Process copied assets
                 for (const copiedAsset of copiedAssets) {
@@ -157,7 +157,7 @@ const hanamiEsbuild = (options) => {
                     var sourceUrl = copiedAsset[0].replace(path.join(options.root, options.baseDir, "assets") + "/", "");
                     // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
                     sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
-                    assetsManifest[sourceUrl] = prepareAsset(destinationUrl);
+                    assetsManifest[sourceUrl] = prepareAsset(copiedAsset[1], destinationUrl);
                 }
                 // Write assets manifest to the destination directory
                 await fs.writeJson(manifestPath, assetsManifest, { spaces: 2 });

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -14,8 +14,6 @@ const hanamiEsbuild = (options) => {
             build.initialOptions.metafile = true;
             options.root = options.root || process.cwd(); // TODO: can't this always be passed in?
             const manifestPath = path.join(options.root, options.destDir, "assets.json");
-            // console.log("externalDirs")
-            // console.log(build.initialOptions.external)
             const externalDirs = build.initialOptions.external || [];
             build.onEnd(async (result) => {
                 const outputs = result.metafile?.outputs;
@@ -89,10 +87,6 @@ const hanamiEsbuild = (options) => {
                     const dirPath = path.dirname(pattern);
                     const files = fs.readdirSync(dirPath, { recursive: true });
                     const assets = [];
-                    // console.log(`processAssetDirectory for ${pattern}`)
-                    // console.log(dirPath)
-                    // console.log(files)
-                    // console.log(inputs)
                     files.forEach((file) => {
                         const srcPath = path.join(dirPath, file.toString());
                         // Skip if the file is already processed by esbuild
@@ -121,7 +115,6 @@ const hanamiEsbuild = (options) => {
                 if (typeof outputs === "undefined") {
                     return;
                 }
-                // console.log(outputs)
                 // TODO: change name of `inputs` to something clearer...
                 const compiledEntryPoints = extractEsbuildCompiledEntrypoints(outputs);
                 // TODO: use a more explicit type than this. an array of records with named properties?

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -55,14 +55,13 @@ const hanamiEsbuild = (options) => {
                 //  To this:
                 //
                 // {
-                //   'public/assets/admin/app-ITGLRDE7.js': 'slices/admin/assets/js/app.js'
+                //   'public/assets/admin/app-ITGLRDE7.js': true
                 // }
                 function extractEsbuildCompiledEntrypoints(esbuildOutputs) {
                     const entryPoints = {};
                     for (const key in esbuildOutputs) {
-                        const output = esbuildOutputs[key];
-                        if (output.entryPoint) {
-                            entryPoints[key] = output.entryPoint;
+                        if (!key.endsWith(".map")) {
+                            entryPoints[key] = true;
                         }
                     }
                     return entryPoints;

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -135,8 +135,11 @@ const hanamiEsbuild = (options) => {
                 }
                 // Process entrypoints
                 for (const compiledEntryPoint in compiledEntryPoints) {
+                    // Convert "public/assets/app-2TLUHCQ6.js" to "app.js"
+                    let sourceUrl = compiledEntryPoint
+                        .replace(options.destDir + "/", "")
+                        .replace(/(-[A-Z0-9]{8})(\.\S+)$/, "$2");
                     const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
-                    const sourceUrl = compiledEntryPoints[compiledEntryPoint].replace(`${options.baseDir}/assets/js/`, "");
                     assetsManifest[sourceUrl] = prepareAsset(compiledEntryPoint, destinationUrl);
                 }
                 // Process copied assets

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -113,7 +113,6 @@ const hanamiEsbuild = (options) => {
                 if (typeof outputs === "undefined") {
                     return;
                 }
-                // TODO: change name of `inputs` to something clearer...
                 const compiledEntryPoints = extractEsbuildCompiledEntrypoints(outputs);
                 // TODO: use a more explicit type than this. an array of records with named properties?
                 const copiedAssets = [];

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -56,7 +56,7 @@ export const buildOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
         root: root,
-        baseDir: args.path,
+        sourceDir: args.path,
         destDir: args.dest,
         sriAlgorithms: args.sri || [],
     };
@@ -80,7 +80,7 @@ export const watchOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
         root: root,
-        baseDir: args.path,
+        sourceDir: args.path,
         destDir: args.dest,
         hash: false,
     };

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -55,6 +55,7 @@ const findExternalDirectories = (basePath) => {
 export const buildOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
+        root: root,
         baseDir: args.path,
         destDir: args.dest,
         sriAlgorithms: args.sri || [],
@@ -78,6 +79,7 @@ export const buildOptions = (root, args) => {
 export const watchOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
+        root: root,
         baseDir: args.path,
         destDir: args.dest,
         hash: false,

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -21,9 +21,7 @@ const loader = {
 const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
 const findEntryPoints = (sliceRoot) => {
     const result = {};
-    const entryPoints = globSync([
-        path.join(sliceRoot, "assets", "js", "**", entryPointExtensions),
-    ]);
+    const entryPoints = globSync([path.join(sliceRoot, "assets", "js", "**", entryPointExtensions)]);
     entryPoints.forEach((entryPoint) => {
         let entryPointPath = entryPoint.replace(sliceRoot + "/assets/js/", "");
         const { dir, name } = path.parse(entryPointPath);
@@ -37,12 +35,8 @@ const findEntryPoints = (sliceRoot) => {
     });
     return result;
 };
-// TODO: feels like this really should be passed a root too, to become the cwd for globSync
-const externalDirectories = () => {
-    const assetDirsPattern = [
-        path.join("app", "assets", "*"),
-        path.join("slices", "*", "assets", "*"),
-    ];
+const findExternalDirectories = (basePath) => {
+    const assetDirsPattern = [path.join(basePath, "assets", "*")];
     const excludeDirs = ["js", "css"];
     try {
         const dirs = globSync(assetDirsPattern, { nodir: false });
@@ -61,6 +55,7 @@ const externalDirectories = () => {
 export const buildOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
+        baseDir: args.path,
         destDir: args.target,
         sriAlgorithms: args.sri || [],
     };
@@ -70,7 +65,7 @@ export const buildOptions = (root, args) => {
         outdir: args.target,
         absWorkingDir: root,
         loader: loader,
-        external: externalDirectories(),
+        external: findExternalDirectories(path.join(root, args.path)),
         logLevel: "info",
         minify: true,
         sourcemap: true,
@@ -83,6 +78,7 @@ export const buildOptions = (root, args) => {
 export const watchOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
+        baseDir: args.path,
         destDir: args.target,
         hash: false,
     };
@@ -92,7 +88,7 @@ export const watchOptions = (root, args) => {
         outdir: args.target,
         absWorkingDir: root,
         loader: loader,
-        external: externalDirectories(),
+        external: findExternalDirectories(path.join(root, args.path)),
         logLevel: "info",
         minify: false,
         sourcemap: false,

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -19,26 +19,21 @@ const loader = {
     ".ttf": "file",
 };
 const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
-// FIXME: make cross platform
-const entryPointsMatcher = /(app\/assets\/js\/|slices\/(.*\/)assets\/js\/)/;
-const findEntryPoints = (root) => {
+const findEntryPoints = (sliceRoot) => {
     const result = {};
-    // TODO: should this be done explicitly within the root?
     const entryPoints = globSync([
-        path.join("app", "assets", "js", "**", entryPointExtensions),
-        path.join("slices", "*", "assets", "js", "**", entryPointExtensions),
+        path.join(sliceRoot, "assets", "js", "**", entryPointExtensions),
     ]);
     entryPoints.forEach((entryPoint) => {
-        let modifiedPath = entryPoint.replace(entryPointsMatcher, "$2");
-        const relativePath = path.relative(root, modifiedPath);
-        const { dir, name } = path.parse(relativePath);
+        let entryPointPath = entryPoint.replace(sliceRoot + "/assets/js/", "");
+        const { dir, name } = path.parse(entryPointPath);
         if (dir) {
-            modifiedPath = path.join(dir, name);
+            entryPointPath = path.join(dir, name);
         }
         else {
-            modifiedPath = name;
+            entryPointPath = name;
         }
-        result[modifiedPath] = entryPoint;
+        result[entryPointPath] = entryPoint;
     });
     return result;
 };
@@ -79,7 +74,7 @@ export const buildOptions = (root, args) => {
         minify: true,
         sourcemap: true,
         entryNames: "[dir]/[name]-[hash]",
-        entryPoints: findEntryPoints(root),
+        entryPoints: findEntryPoints(path.join(root, args.path)),
         plugins: [plugin],
     };
     return options;
@@ -100,7 +95,7 @@ export const watchOptions = (root, args) => {
         minify: false,
         sourcemap: false,
         entryNames: "[dir]/[name]",
-        entryPoints: findEntryPoints(root),
+        entryPoints: findEntryPoints(path.join(root, args.path)),
         plugins: [plugin],
     };
     return options;

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -56,13 +56,13 @@ export const buildOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
         baseDir: args.path,
-        destDir: args.target,
+        destDir: args.dest,
         sriAlgorithms: args.sri || [],
     };
     const plugin = esbuildPlugin(pluginOptions);
     const options = {
         bundle: true,
-        outdir: args.target,
+        outdir: args.dest,
         absWorkingDir: root,
         loader: loader,
         external: findExternalDirectories(path.join(root, args.path)),
@@ -79,13 +79,13 @@ export const watchOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
         baseDir: args.path,
-        destDir: args.target,
+        destDir: args.dest,
         hash: false,
     };
     const plugin = esbuildPlugin(pluginOptions);
     const options = {
         bundle: true,
-        outdir: args.target,
+        outdir: args.dest,
         absWorkingDir: root,
         loader: loader,
         external: findExternalDirectories(path.join(root, args.path)),

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -61,6 +61,7 @@ const externalDirectories = () => {
 export const buildOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
+        destDir: args.target,
         sriAlgorithms: args.sri || [],
     };
     const plugin = esbuildPlugin(pluginOptions);
@@ -82,6 +83,7 @@ export const buildOptions = (root, args) => {
 export const watchOptions = (root, args) => {
     const pluginOptions = {
         ...pluginDefaults,
+        destDir: args.target,
         hash: false,
     };
     const plugin = esbuildPlugin(pluginOptions);

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -66,7 +66,7 @@ export const buildOptions = (root, args) => {
     const plugin = esbuildPlugin(pluginOptions);
     const options = {
         bundle: true,
-        outdir: path.join(root, "public", "assets"),
+        outdir: args.target,
         absWorkingDir: root,
         loader: loader,
         external: externalDirectories(),
@@ -87,7 +87,7 @@ export const watchOptions = (root, args) => {
     const plugin = esbuildPlugin(pluginOptions);
     const options = {
         bundle: true,
-        outdir: path.join(root, "public", "assets"),
+        outdir: args.target,
         absWorkingDir: root,
         loader: loader,
         external: externalDirectories(),

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -18,10 +18,13 @@ const loader = {
     ".eot": "file",
     ".ttf": "file",
 };
+const assetsDirName = "assets";
 const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
 const findEntryPoints = (sliceRoot) => {
     const result = {};
-    const entryPoints = globSync([path.join(sliceRoot, "assets", "js", "**", entryPointExtensions)]);
+    const entryPoints = globSync([
+        path.join(sliceRoot, assetsDirName, "js", "**", entryPointExtensions),
+    ]);
     entryPoints.forEach((entryPoint) => {
         let entryPointPath = entryPoint.replace(sliceRoot + "/assets/js/", "");
         const { dir, name } = path.parse(entryPointPath);
@@ -36,7 +39,7 @@ const findEntryPoints = (sliceRoot) => {
     return result;
 };
 const findExternalDirectories = (basePath) => {
-    const assetDirsPattern = [path.join(basePath, "assets", "*")];
+    const assetDirsPattern = [path.join(basePath, assetsDirName, "*")];
     const excludeDirs = ["js", "css"];
     try {
         const dirs = globSync(assetDirsPattern, { nodir: false });

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { BuildContext } from "esbuild";
 import { Args } from "./args.js";
 import { EsbuildOptions } from "./esbuild.js";

--- a/dist/index.js
+++ b/dist/index.js
@@ -5,6 +5,7 @@ import esbuild from "esbuild";
 import { parseArgs } from "./args.js";
 import { buildOptions, watchOptions } from "./esbuild.js";
 export const run = async function (options) {
+    // TODO: Allow root to be provided (optionally) as a --root arg
     const { root = process.cwd(), argv = process.argv, esbuildOptionsFn = null } = options || {};
     const args = parseArgs(argv);
     // TODO: make nicer

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import fs from "fs-extra";
 import path from "path";
 import esbuild from "esbuild";

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,5 +1,6 @@
 export interface Args {
   path: string;
+  target: string;
   watch: Boolean;
   sri: string[] | null;
 }
@@ -14,6 +15,7 @@ export const parseArgs = (args: string[]): Args => {
 
   return {
     path: result["path"],
+    target: result["target"],
     watch: result.hasOwnProperty("watch"),
     sri: result["sri"]?.split(","),
   };

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,4 +1,5 @@
 export interface Args {
+  path: string;
   watch: Boolean;
   sri: string[] | null;
 }
@@ -12,6 +13,7 @@ export const parseArgs = (args: string[]): Args => {
   });
 
   return {
+    path: result["path"],
     watch: result.hasOwnProperty("watch"),
     sri: result["sri"]?.split(","),
   };

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,6 +1,6 @@
 export interface Args {
   path: string;
-  target: string;
+  dest: string;
   watch: Boolean;
   sri: string[] | null;
 }
@@ -15,7 +15,7 @@ export const parseArgs = (args: string[]): Args => {
 
   return {
     path: result["path"],
-    target: result["target"],
+    dest: result["dest"],
     watch: result.hasOwnProperty("watch"),
     sri: result["sri"]?.split(","),
   };

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -198,11 +198,12 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
         // Process entrypoints
         for (const compiledEntryPoint in compiledEntryPoints) {
+          // Convert "public/assets/app-2TLUHCQ6.js" to "app.js"
+          let sourceUrl = compiledEntryPoint
+            .replace(options.destDir + "/", "")
+            .replace(/(-[A-Z0-9]{8})(\.\S+)$/, "$2")
+
           const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
-          const sourceUrl = compiledEntryPoints[compiledEntryPoint].replace(
-            `${options.baseDir}/assets/js/`,
-            "",
-          );
 
           assetsManifest[sourceUrl] = prepareAsset(compiledEntryPoint, destinationUrl);
         }

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -33,8 +33,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
       options.root = options.root || process.cwd(); // TODO: can't this always be passed in?
 
       const manifestPath = path.join(options.root, options.destDir, "assets.json");
-      // console.log("externalDirs")
-      // console.log(build.initialOptions.external)
       const externalDirs = build.initialOptions.external || [];
 
       build.onEnd(async (result: BuildResult) => {
@@ -133,12 +131,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           const files = fs.readdirSync(dirPath, { recursive: true });
           const assets: string[][] = [];
 
-          // console.log(`processAssetDirectory for ${pattern}`)
-          // console.log(dirPath)
-          // console.log(files)
-
-          // console.log(inputs)
-
           files.forEach((file) => {
             const srcPath = path.join(dirPath, file.toString());
 
@@ -176,8 +168,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         if (typeof outputs === "undefined") {
           return;
         }
-
-        // console.log(outputs)
 
         // TODO: change name of `inputs` to something clearer...
         const compiledEntryPoints = extractEsbuildCompiledEntrypoints(outputs);

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -13,10 +13,7 @@ export interface PluginOptions {
   hash: boolean;
 }
 
-export const defaults: Pick<
-  PluginOptions,
-  "root" | "sriAlgorithms" | "hash"
-> = {
+export const defaults: Pick<PluginOptions, "root" | "sriAlgorithms" | "hash"> = {
   root: "",
   sriAlgorithms: [],
   hash: true,
@@ -90,7 +87,9 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         // {
         //   'public/assets/admin/app-ITGLRDE7.js': 'slices/admin/assets/js/app.js'
         // }
-        function extractEsbuildCompiledEntrypoints(esbuildOutputs: Record<string, any>): Record<string, string> {
+        function extractEsbuildCompiledEntrypoints(
+          esbuildOutputs: Record<string, any>,
+        ): Record<string, string> {
           const entryPoints: Record<string, string> = {};
 
           for (const key in esbuildOutputs) {
@@ -196,7 +195,10 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
             asset.sri = [];
 
             for (const algorithm of options.sriAlgorithms) {
-              const subresourceIntegrity = calculateSubresourceIntegrity(algorithm, path.join(options.root, assetPath));
+              const subresourceIntegrity = calculateSubresourceIntegrity(
+                algorithm,
+                path.join(options.root, assetPath),
+              );
               asset.sri.push(subresourceIntegrity);
             }
           }
@@ -207,7 +209,10 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         // Process entrypoints
         for (const compiledEntryPoint in compiledEntryPoints) {
           const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
-          const sourceUrl = compiledEntryPoints[compiledEntryPoint].replace(`${options.baseDir}/assets/js/`, "")
+          const sourceUrl = compiledEntryPoints[compiledEntryPoint].replace(
+            `${options.baseDir}/assets/js/`,
+            "",
+          );
 
           assetsManifest[sourceUrl] = prepareAsset(compiledEntryPoint, destinationUrl);
         }
@@ -222,7 +227,10 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           const destinationUrl = calulateDestinationUrl(copiedAsset[1]);
 
           // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
-          var sourceUrl = copiedAsset[0].replace(path.join(options.root, options.baseDir, "assets") + "/", "")
+          var sourceUrl = copiedAsset[0].replace(
+            path.join(options.root, options.baseDir, "assets") + "/",
+            "",
+          );
           // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
           sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
 

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -7,7 +7,6 @@ const URL_SEPARATOR = "/";
 
 export interface PluginOptions {
   root: string;
-  publicDir: string;
   destDir: string;
   manifestPath: string;
   sriAlgorithms: Array<string>;
@@ -16,10 +15,9 @@ export interface PluginOptions {
 
 export const defaults: Pick<
   PluginOptions,
-  "root" | "publicDir" | "destDir" | "manifestPath" | "sriAlgorithms" | "hash"
+  "root" | "destDir" | "manifestPath" | "sriAlgorithms" | "hash"
 > = {
   root: "",
-  publicDir: "public",
   destDir: path.join("public", "assets"),
   manifestPath: path.join("public", "assets.json"),
   sriAlgorithms: [],

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -23,6 +23,8 @@ interface Asset {
   sri?: Array<string>;
 }
 
+const assetsDirName = "assets";
+
 const hanamiEsbuild = (options: PluginOptions): Plugin => {
   return {
     name: "hanami-esbuild",
@@ -215,7 +217,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
           // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
           var sourceUrl = copiedAsset[0].replace(
-            path.join(options.root, options.sourceDir, "assets") + "/",
+            path.join(options.root, options.sourceDir, assetsDirName) + "/",
             "",
           );
           // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -189,14 +189,14 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           copiedAssets.push(...processAssetDirectory(pattern, compiledEntryPoints, options));
         });
 
-        function prepareAsset(destinationUrl: string): Asset {
+        function prepareAsset(assetPath: string, destinationUrl: string): Asset {
           var asset: Asset = { url: destinationUrl };
 
           if (options.sriAlgorithms.length > 0) {
             asset.sri = [];
 
             for (const algorithm of options.sriAlgorithms) {
-              const subresourceIntegrity = calculateSubresourceIntegrity(algorithm, destinationUrl);
+              const subresourceIntegrity = calculateSubresourceIntegrity(algorithm, path.join(options.root, assetPath));
               asset.sri.push(subresourceIntegrity);
             }
           }
@@ -209,7 +209,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
           const sourceUrl = compiledEntryPoints[compiledEntryPoint].replace(`${options.baseDir}/assets/js/`, "")
 
-          assetsManifest[sourceUrl] = prepareAsset(destinationUrl);
+          assetsManifest[sourceUrl] = prepareAsset(compiledEntryPoint, destinationUrl);
         }
 
         // Process copied assets
@@ -226,7 +226,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
           sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
 
-          assetsManifest[sourceUrl] = prepareAsset(destinationUrl);
+          assetsManifest[sourceUrl] = prepareAsset(copiedAsset[1], destinationUrl);
         }
 
         // Write assets manifest to the destination directory

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -23,6 +23,11 @@ interface Asset {
   sri?: Array<string>;
 }
 
+interface CopiedAsset {
+  sourcePath: string;
+  destPath: string;
+}
+
 const assetsDirName = "assets";
 
 const hanamiEsbuild = (options: PluginOptions): Plugin => {
@@ -124,39 +129,41 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           pattern: string,
           compiledEntryPoints: Record<string, boolean>,
           options: PluginOptions,
-        ): string[][] => {
+        ): CopiedAsset[] => {
           const dirPath = path.dirname(pattern);
           const files = fs.readdirSync(dirPath, { recursive: true });
-          const assets: string[][] = [];
+          const assets: CopiedAsset[] = [];
 
           files.forEach((file) => {
-            const srcPath = path.join(dirPath, file.toString());
+            const sourcePath = path.join(dirPath, file.toString());
 
             // Skip if the file is already processed by esbuild
-            if (compiledEntryPoints.hasOwnProperty(srcPath)) {
+            if (compiledEntryPoints.hasOwnProperty(sourcePath)) {
               return;
             }
 
             // Skip directories and any other non-files
-            if (!fs.statSync(srcPath).isFile()) {
+            if (!fs.statSync(sourcePath).isFile()) {
               return;
             }
 
-            const fileHash = calculateHash(fs.readFileSync(srcPath), options.hash);
-            const fileExtension = path.extname(srcPath);
-            const baseName = path.basename(srcPath, fileExtension);
+            const fileHash = calculateHash(fs.readFileSync(sourcePath), options.hash);
+            const fileExtension = path.extname(sourcePath);
+            const baseName = path.basename(sourcePath, fileExtension);
             const destFileName =
               [baseName, fileHash].filter((item) => item !== null).join("-") + fileExtension;
             const destPath = path.join(
               options.destDir,
-              path.relative(dirPath, srcPath).replace(path.basename(file.toString()), destFileName),
+              path
+                .relative(dirPath, sourcePath)
+                .replace(path.basename(file.toString()), destFileName),
             );
 
-            if (fs.lstatSync(srcPath).isDirectory()) {
+            if (fs.lstatSync(sourcePath).isDirectory()) {
               assets.push(...processAssetDirectory(destPath, compiledEntryPoints, options));
             } else {
-              copyAsset(srcPath, destPath);
-              assets.push([srcPath, destPath]);
+              copyAsset(sourcePath, destPath);
+              assets.push({ sourcePath: sourcePath, destPath: destPath });
             }
           });
 
@@ -169,8 +176,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
         const compiledEntryPoints = extractEsbuildCompiledEntrypoints(outputs);
 
-        // TODO: use a more explicit type than this. an array of records with named properties?
-        const copiedAssets: string[][] = [];
+        const copiedAssets: CopiedAsset[] = [];
         externalDirs.forEach((pattern) => {
           copiedAssets.push(...processAssetDirectory(pattern, compiledEntryPoints, options));
         });
@@ -209,21 +215,21 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         // Process copied assets
         for (const copiedAsset of copiedAssets) {
           // TODO: I wonder if we can skip .map files earlier
-          if (copiedAsset[0].endsWith(".map")) {
+          if (copiedAsset.sourcePath.endsWith(".map")) {
             continue;
           }
 
-          const destinationUrl = calulateDestinationUrl(copiedAsset[1]);
+          const destinationUrl = calulateDestinationUrl(copiedAsset.destPath);
 
           // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
-          var sourceUrl = copiedAsset[0].replace(
+          var sourceUrl = copiedAsset.sourcePath.replace(
             path.join(options.root, options.sourceDir, assetsDirName) + "/",
             "",
           );
           // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
           sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
 
-          assetsManifest[sourceUrl] = prepareAsset(copiedAsset[1], destinationUrl);
+          assetsManifest[sourceUrl] = prepareAsset(copiedAsset.destPath, destinationUrl);
         }
 
         // Write assets manifest to the destination directory

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -167,7 +167,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           return;
         }
 
-        // TODO: change name of `inputs` to something clearer...
         const compiledEntryPoints = extractEsbuildCompiledEntrypoints(outputs);
 
         // TODO: use a more explicit type than this. an array of records with named properties?

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -199,7 +199,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           // Convert "public/assets/app-2TLUHCQ6.js" to "app.js"
           let sourceUrl = compiledEntryPoint
             .replace(options.destDir + "/", "")
-            .replace(/(-[A-Z0-9]{8})(\.\S+)$/, "$2")
+            .replace(/(-[A-Z0-9]{8})(\.\S+)$/, "$2");
 
           const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
 

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -194,11 +194,12 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         }
 
         // Process entrypoints
+        const fileHashRegexp = /(-[A-Z0-9]{8})(\.\S+)$/;
         for (const compiledEntryPoint in compiledEntryPoints) {
           // Convert "public/assets/app-2TLUHCQ6.js" to "app.js"
           let sourceUrl = compiledEntryPoint
             .replace(options.destDir + "/", "")
-            .replace(/(-[A-Z0-9]{8})(\.\S+)$/, "$2");
+            .replace(fileHashRegexp, "$2");
 
           const destinationUrl = calulateDestinationUrl(compiledEntryPoint);
 

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -7,7 +7,7 @@ const URL_SEPARATOR = "/";
 
 export interface PluginOptions {
   root: string;
-  baseDir: string;
+  sourceDir: string;
   destDir: string;
   sriAlgorithms: Array<string>;
   hash: boolean;
@@ -215,7 +215,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
           // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
           var sourceUrl = copiedAsset[0].replace(
-            path.join(options.root, options.baseDir, "assets") + "/",
+            path.join(options.root, options.sourceDir, "assets") + "/",
             "",
           );
           // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -8,18 +8,15 @@ const URL_SEPARATOR = "/";
 export interface PluginOptions {
   root: string;
   destDir: string;
-  manifestPath: string;
   sriAlgorithms: Array<string>;
   hash: boolean;
 }
 
 export const defaults: Pick<
   PluginOptions,
-  "root" | "destDir" | "manifestPath" | "sriAlgorithms" | "hash"
+  "root" | "sriAlgorithms" | "hash"
 > = {
   root: "",
-  destDir: path.join("public", "assets"),
-  manifestPath: path.join("public", "assets.json"),
   sriAlgorithms: [],
   hash: true,
 };
@@ -29,7 +26,7 @@ interface Asset {
   sri?: Array<string>;
 }
 
-const hanamiEsbuild = (options: PluginOptions = { ...defaults }): Plugin => {
+const hanamiEsbuild = (options: PluginOptions): Plugin => {
   return {
     name: "hanami-esbuild",
 
@@ -37,7 +34,7 @@ const hanamiEsbuild = (options: PluginOptions = { ...defaults }): Plugin => {
       build.initialOptions.metafile = true;
       options.root = options.root || process.cwd();
 
-      const manifest = path.join(options.root, options.manifestPath);
+      const manifestPath = path.join(options.root, options.destDir, "assets.json");
       const externalDirs = build.initialOptions.external || [];
 
       build.onEnd(async (result: BuildResult) => {
@@ -191,7 +188,7 @@ const hanamiEsbuild = (options: PluginOptions = { ...defaults }): Plugin => {
         }
 
         // Write assets manifest to the destination directory
-        await fs.writeJson(manifest, assetsManifest, { spaces: 2 });
+        await fs.writeJson(manifestPath, assetsManifest, { spaces: 2 });
       });
     },
   };

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -83,18 +83,16 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         //  To this:
         //
         // {
-        //   'public/assets/admin/app-ITGLRDE7.js': 'slices/admin/assets/js/app.js'
+        //   'public/assets/admin/app-ITGLRDE7.js': true
         // }
         function extractEsbuildCompiledEntrypoints(
           esbuildOutputs: Record<string, any>,
-        ): Record<string, string> {
-          const entryPoints: Record<string, string> = {};
+        ): Record<string, boolean> {
+          const entryPoints: Record<string, boolean> = {};
 
           for (const key in esbuildOutputs) {
-            const output = esbuildOutputs[key];
-
-            if (output.entryPoint) {
-              entryPoints[key] = output.entryPoint;
+            if (!key.endsWith(".map")) {
+              entryPoints[key] = true;
             }
           }
 
@@ -124,7 +122,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
         const processAssetDirectory = (
           pattern: string,
-          compiledEntryPoints: Record<string, string>,
+          compiledEntryPoints: Record<string, boolean>,
           options: PluginOptions,
         ): string[][] => {
           const dirPath = path.dirname(pattern);

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -13,8 +13,7 @@ export interface PluginOptions {
   hash: boolean;
 }
 
-export const defaults: Pick<PluginOptions, "root" | "sriAlgorithms" | "hash"> = {
-  root: "",
+export const defaults: Pick<PluginOptions, "sriAlgorithms" | "hash"> = {
   sriAlgorithms: [],
   hash: true,
 };
@@ -30,7 +29,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
     setup(build: PluginBuild) {
       build.initialOptions.metafile = true;
-      options.root = options.root || process.cwd(); // TODO: can't this always be passed in?
 
       const manifestPath = path.join(options.root, options.destDir, "assets.json");
       const externalDirs = build.initialOptions.external || [];

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -26,12 +26,15 @@ const loader: { [ext: string]: Loader } = {
   ".ttf": "file",
 };
 
+const assetsDirName = "assets";
 const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
 
 const findEntryPoints = (sliceRoot: string): Record<string, string> => {
   const result: Record<string, string> = {};
 
-  const entryPoints = globSync([path.join(sliceRoot, "assets", "js", "**", entryPointExtensions)]);
+  const entryPoints = globSync([
+    path.join(sliceRoot, assetsDirName, "js", "**", entryPointExtensions),
+  ]);
 
   entryPoints.forEach((entryPoint) => {
     let entryPointPath = entryPoint.replace(sliceRoot + "/assets/js/", "");
@@ -51,7 +54,7 @@ const findEntryPoints = (sliceRoot: string): Record<string, string> => {
 };
 
 const findExternalDirectories = (basePath: string): string[] => {
-  const assetDirsPattern = [path.join(basePath, "assets", "*")];
+  const assetDirsPattern = [path.join(basePath, assetsDirName, "*")];
   const excludeDirs = ["js", "css"];
 
   try {

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -85,7 +85,7 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
 
   const options: EsbuildOptions = {
     bundle: true,
-    outdir: path.join(root, "public", "assets"),
+    outdir: args.target,
     absWorkingDir: root,
     loader: loader,
     external: externalDirectories(),
@@ -109,7 +109,7 @@ export const watchOptions = (root: string, args: Args): EsbuildOptions => {
 
   const options: EsbuildOptions = {
     bundle: true,
-    outdir: path.join(root, "public", "assets"),
+    outdir: args.target,
     absWorkingDir: root,
     loader: loader,
     external: externalDirectories(),

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -72,6 +72,7 @@ const findExternalDirectories = (basePath: string): string[] => {
 export const buildOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
+    root: root,
     baseDir: args.path,
     destDir: args.dest,
     sriAlgorithms: args.sri || [],
@@ -98,6 +99,7 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
 export const watchOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
+    root: root,
     baseDir: args.path,
     destDir: args.dest,
     hash: false,

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -79,6 +79,7 @@ const externalDirectories = (): string[] => {
 export const buildOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
+    destDir: args.target,
     sriAlgorithms: args.sri || [],
   };
   const plugin = esbuildPlugin(pluginOptions);
@@ -103,6 +104,7 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
 export const watchOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
+    destDir: args.target,
     hash: false,
   };
   const plugin = esbuildPlugin(pluginOptions);

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -73,7 +73,7 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
     root: root,
-    baseDir: args.path,
+    sourceDir: args.path,
     destDir: args.dest,
     sriAlgorithms: args.sri || [],
   };
@@ -100,7 +100,7 @@ export const watchOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
     root: root,
-    baseDir: args.path,
+    sourceDir: args.path,
     destDir: args.dest,
     hash: false,
   };

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -31,9 +31,7 @@ const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
 const findEntryPoints = (sliceRoot: string): Record<string, string> => {
   const result: Record<string, string> = {};
 
-  const entryPoints = globSync([
-    path.join(sliceRoot, "assets", "js", "**", entryPointExtensions),
-  ]);
+  const entryPoints = globSync([path.join(sliceRoot, "assets", "js", "**", entryPointExtensions)]);
 
   entryPoints.forEach((entryPoint) => {
     let entryPointPath = entryPoint.replace(sliceRoot + "/assets/js/", "");
@@ -52,13 +50,8 @@ const findEntryPoints = (sliceRoot: string): Record<string, string> => {
   return result;
 };
 
-// TODO: feels like this really should be passed a root too, to become the cwd for globSync
-const externalDirectories = (): string[] => {
-  const assetDirsPattern = [
-    path.join("app", "assets", "*"),
-    path.join("slices", "*", "assets", "*"),
-  ];
-
+const findExternalDirectories = (basePath: string): string[] => {
+  const assetDirsPattern = [path.join(basePath, "assets", "*")];
   const excludeDirs = ["js", "css"];
 
   try {
@@ -90,7 +83,7 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
     outdir: args.target,
     absWorkingDir: root,
     loader: loader,
-    external: externalDirectories(),
+    external: findExternalDirectories(path.join(root, args.path)),
     logLevel: "info",
     minify: true,
     sourcemap: true,
@@ -116,7 +109,7 @@ export const watchOptions = (root: string, args: Args): EsbuildOptions => {
     outdir: args.target,
     absWorkingDir: root,
     loader: loader,
-    external: externalDirectories(),
+    external: findExternalDirectories(path.join(root, args.path)),
     logLevel: "info",
     minify: false,
     sourcemap: false,

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -73,14 +73,14 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
     baseDir: args.path,
-    destDir: args.target,
+    destDir: args.dest,
     sriAlgorithms: args.sri || [],
   };
   const plugin = esbuildPlugin(pluginOptions);
 
   const options: EsbuildOptions = {
     bundle: true,
-    outdir: args.target,
+    outdir: args.dest,
     absWorkingDir: root,
     loader: loader,
     external: findExternalDirectories(path.join(root, args.path)),
@@ -99,14 +99,14 @@ export const watchOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
     baseDir: args.path,
-    destDir: args.target,
+    destDir: args.dest,
     hash: false,
   };
   const plugin = esbuildPlugin(pluginOptions);
 
   const options: EsbuildOptions = {
     bundle: true,
-    outdir: args.target,
+    outdir: args.dest,
     absWorkingDir: root,
     loader: loader,
     external: findExternalDirectories(path.join(root, args.path)),

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -79,6 +79,7 @@ const externalDirectories = (): string[] => {
 export const buildOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
+    baseDir: args.path,
     destDir: args.target,
     sriAlgorithms: args.sri || [],
   };
@@ -104,6 +105,7 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
 export const watchOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...pluginDefaults,
+    baseDir: args.path,
     destDir: args.target,
     hash: false,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ interface RunOptions {
 type EsbuildOptionsFn = (args: Args, esbuildOptions: EsbuildOptions) => EsbuildOptions;
 
 export const run = async function (options?: RunOptions): Promise<BuildContext | void> {
+  // TODO: Allow root to be provided (optionally) as a --root arg
   const { root = process.cwd(), argv = process.argv, esbuildOptionsFn = null } = options || {};
 
   const args = parseArgs(argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import fs from "fs-extra";
 import path from "path";
 import esbuild, { BuildContext } from "esbuild";

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -54,7 +54,7 @@ describe("hanami-assets", () => {
     await fs.writeFile(sliceImage, "");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets"] });
+    await assets.run({ root: dest, argv: ["--path=app", "--dest=public/assets"] });
 
     // FIXME: this path should take into account the file hashing in the file name
     const appAsset = globSync(path.join("public/assets/app-*.js"))[0];
@@ -100,7 +100,7 @@ describe("hanami-assets", () => {
     await fs.writeFile(sliceFont, "slice-font");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=slices/admin", "--target=public/assets/admin"] });
+    await assets.run({ root: dest, argv: ["--path=slices/admin", "--dest=public/assets/admin"] });
 
     // FIXME: this path should take into account the file hashing in the file name
     const sliceAsset = globSync(path.join("public/assets/admin/app-*.js"))[0];
@@ -138,7 +138,7 @@ describe("hanami-assets", () => {
     // Compile assets
     await assets.run({
       root: dest,
-      argv: ["--path=app", "--target=public/assets", "--sri=sha256,sha384,sha512"],
+      argv: ["--path=app", "--dest=public/assets", "--sri=sha256,sha384,sha512"],
     });
 
     // Read and parse the manifest file
@@ -167,7 +167,7 @@ describe("hanami-assets", () => {
     const cssFile = path.join(dest, "app/assets/css/app.css");
     await fs.writeFile(cssFile, ".btn { background: #f00; }");
 
-    await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets"] });
+    await assets.run({ root: dest, argv: ["--path=app", "--dest=public/assets"] });
 
     const entryPointExists = await fs.pathExists(path.join("public/assets/app-6PW7FGD5.js"));
     expect(entryPointExists).toBe(true);
@@ -197,7 +197,7 @@ describe("hanami-assets", () => {
     await fs.writeFile(entryPoint2, "console.log('Hello from TSX!');");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets"] });
+    await assets.run({ root: dest, argv: ["--path=app", "--dest=public/assets"] });
 
     const asset1Exists = await fs.pathExists(path.join("public/assets/app-2TLUHCQ6.js"));
     expect(asset1Exists).toBe(true);
@@ -244,7 +244,7 @@ describe("hanami-assets", () => {
       // Watch for asset changes
       let ctx = await assets.run({
         root: dest,
-        argv: ["--path=app", "--target=public/assets", "--watch"],
+        argv: ["--path=app", "--dest=public/assets", "--watch"],
       });
 
       await fs.writeFile(entryPoint, "console.log('Hello, Watch!');");

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -165,7 +165,7 @@ describe("hanami-assets", () => {
       const imageAsset = path.join(dest, "public", "assets", "background.jpg");
 
       // Watch for asset changes
-      let ctx = await assets.run({ root: dest, argv: ["--path=app", "--watch"] });
+      let ctx = await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets", "--watch"] });
 
       await fs.writeFile(entryPoint, "console.log('Hello, Watch!');");
 
@@ -200,11 +200,11 @@ describe("hanami-assets", () => {
       // Check if the asset has the expected contents
       expect(assetContent).toMatch('console.log("Hello, Watch!");');
 
-      const manifestExists = await fs.pathExists(path.join(dest, "public/assets.json"));
+      const manifestExists = await fs.pathExists(path.join(dest, "public/assets/assets.json"));
       expect(manifestExists).toBe(true);
 
       // Read and parse the manifest file
-      const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
+      const manifestContent = await fs.readFile(path.join(dest, "public/assets/assets.json"), "utf-8");
       const manifest = JSON.parse(manifestContent);
 
       expect(manifest["background.jpg"]).toEqual({

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -61,11 +61,11 @@ describe("hanami-assets", () => {
     // const sliceAssetExists2 = await fs.pathExists(sliceAsset2);
     // expect(sliceAssetExists2).toBe(true);
 
-    const manifestExists = await fs.pathExists(path.join(dest, "public/assets.json"));
+    const manifestExists = await fs.pathExists(path.join(dest, "public/assets/assets.json"));
     expect(manifestExists).toBe(true);
 
     // Read and parse the manifest file
-    const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
+    const manifestContent = await fs.readFile(path.join(dest, "public/assets/assets.json"), "utf-8");
     const manifest = JSON.parse(manifestContent);
 
     // Check if the manifest contains the correct file paths

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -12,8 +12,9 @@ const watchTimeout = 60000; // ms (60 seconds)
 async function createTestEnvironment() {
   // Create temporary directories
   await fs.ensureDir(path.join(dest, "app/assets/js"));
-  await fs.ensureDir(path.join(dest, "app/assets/images"));
+  await fs.ensureDir(path.join(dest, "app/assets/images/nested"));
   await fs.ensureDir(path.join(dest, "slices/admin/assets/js"));
+  await fs.ensureDir(path.join(dest, "slices/admin/assets/images/nested"));
   await fs.ensureDir(path.join(dest, "slices/metrics/assets/js"));
   await fs.ensureDir(path.join(dest, "public"));
 
@@ -37,11 +38,16 @@ describe("hanami-assets", () => {
   });
 
   test("copies assets from the app to public/assets and generates a manifest file", async () => {
-    // Prepate both app and assets slices to make it clear the slice assets are _not_ compiled here
-    const entryPoint1 = path.join(dest, "app/assets/js/app.js");
-    const entryPoint2 = path.join(dest, "slices/admin/assets/js/app.js");
-    await fs.writeFile(entryPoint1, "console.log('Hello, World!');");
-    await fs.writeFile(entryPoint2, "console.log('Hello, Admin!');");
+    // Prepare both app and assets slices to make it clear the slice assets are _not_ compiled here
+    const appEntryPoint = path.join(dest, "app/assets/js/app.js");
+    await fs.writeFile(appEntryPoint, "console.log('Hello, World!');");
+    const appImage = path.join(dest, "app/assets/images/nested/app-image.jpg");
+    await fs.writeFile(appImage, "");
+
+    const sliceEntryPoint = path.join(dest, "slices/admin/assets/js/app.js");
+    await fs.writeFile(sliceEntryPoint, "console.log('Hello, Admin!');");
+    const sliceImage = path.join(dest, "slices/admin/assets/images/nested/slice-image.jpg");
+    await fs.writeFile(sliceImage, "");
 
     // Compile assets
     await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets"] });
@@ -63,15 +69,23 @@ describe("hanami-assets", () => {
       "app.js": {
         url: "/assets/app-JLSTK5SN.js",
       },
+      "nested/app-image.jpg": {
+        url: "/assets/nested/app-image-E3B0C442.jpg",
+      },
     });
   });
 
   test("copies assets from an admin slice to public/assets/admin and generates a manifest file", async () => {
     // Prepate both app and assets slices to make it clear the app assets are _not_ compiled here
-    const entryPoint1 = path.join(dest, "app/assets/js/app.js");
-    const entryPoint2 = path.join(dest, "slices/admin/assets/js/app.js");
-    await fs.writeFile(entryPoint1, "console.log('Hello, World!');");
-    await fs.writeFile(entryPoint2, "console.log('Hello, Admin!');");
+    const appEntryPoint = path.join(dest, "app/assets/js/app.js");
+    await fs.writeFile(appEntryPoint, "console.log('Hello, World!');");
+    const appImage = path.join(dest, "app/assets/images/nested/app-image.jpg");
+    await fs.writeFile(appImage, "");
+
+    const sliceEntryPoint = path.join(dest, "slices/admin/assets/js/app.js");
+    await fs.writeFile(sliceEntryPoint, "console.log('Hello, Admin!');");
+    const sliceImage = path.join(dest, "slices/admin/assets/images/nested/slice-image.jpg");
+    await fs.writeFile(sliceImage, "");
 
     // Compile assets
     await assets.run({ root: dest, argv: ["--path=slices/admin", "--target=public/assets/admin"] });
@@ -90,8 +104,11 @@ describe("hanami-assets", () => {
 
     // Check if the manifest contains the correct file paths
     expect(manifest).toEqual({
-      "app.js": {  // FIXME THIS IS RETURNING admin/app.js, WE DON'T WANT THAT NAMESPACINGt
+      "app.js": {
         url: "/assets/admin/app-ITGLRDE7.js",
+      },
+      "nested/slice-image.jpg": {
+        url: "/assets/admin/nested/slice-image-E3B0C442.jpg",
       },
     });
   });

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -44,7 +44,7 @@ describe("hanami-assets", () => {
     await fs.writeFile(entryPoint3, "console.log('Hello, Metrics!');");
 
     // Compile assets
-    await assets.run({ root: dest });
+    await assets.run({ root: dest, argv: ["--path=app"] });
 
     // FIXME: this path should take into account the file hashing in the file name
     const appAsset = globSync(path.join("public/assets/app-*.js"))[0];
@@ -52,14 +52,14 @@ describe("hanami-assets", () => {
     expect(appAssetExists).toBe(true);
 
     // FIXME: this path should take into account the file hashing in the file name
-    const sliceAsset1 = globSync(path.join("public/assets/admin/app-*.js"))[0];
-    const sliceAssetExists1 = await fs.pathExists(sliceAsset1);
-    expect(sliceAssetExists1).toBe(true);
+    // const sliceAsset1 = globSync(path.join("public/assets/admin/app-*.js"))[0];
+    // const sliceAssetExists1 = await fs.pathExists(sliceAsset1);
+    // expect(sliceAssetExists1).toBe(true);
 
     // FIXME: this path should take into account the file hashing in the file name
-    const sliceAsset2 = globSync(path.join("public/assets/metrics/app-*.js"))[0];
-    const sliceAssetExists2 = await fs.pathExists(sliceAsset2);
-    expect(sliceAssetExists2).toBe(true);
+    // const sliceAsset2 = globSync(path.join("public/assets/metrics/app-*.js"))[0];
+    // const sliceAssetExists2 = await fs.pathExists(sliceAsset2);
+    // expect(sliceAssetExists2).toBe(true);
 
     const manifestExists = await fs.pathExists(path.join(dest, "public/assets.json"));
     expect(manifestExists).toBe(true);
@@ -70,15 +70,15 @@ describe("hanami-assets", () => {
 
     // Check if the manifest contains the correct file paths
     expect(manifest).toEqual({
-      "admin/app.js": {
-        url: "/assets/admin/app-NLRESL5A.js",
-      },
+      // "admin/app.js": {
+      //   url: "/assets/admin/app-NLRESL5A.js",
+      // },
       "app.js": {
         url: "/assets/app-JLSTK5SN.js",
       },
-      "metrics/app.js": {
-        url: "/assets/metrics/app-27Z7ZALS.js",
-      },
+      // "metrics/app.js": {
+      //   url: "/assets/metrics/app-27Z7ZALS.js",
+      // },
     });
   });
 
@@ -87,7 +87,7 @@ describe("hanami-assets", () => {
     await fs.writeFile(entryPoint1, "console.log('Hello, World!');");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--sri=sha256,sha384,sha512"] });
+    await assets.run({ root: dest, argv: ["--path=app --sri=sha256,sha384,sha512"] });
 
     // Read and parse the manifest file
     const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
@@ -110,7 +110,7 @@ describe("hanami-assets", () => {
     fs.copySync(path.join(__dirname, "fixtures", "todo"), dest);
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--sri=sha384"] });
+    await assets.run({ root: dest, argv: ["--path=app --sri=sha384"] });
 
     // Read and parse the manifest file
     const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
@@ -170,7 +170,7 @@ describe("hanami-assets", () => {
       const imageAsset = path.join(dest, "public", "assets", "background.jpg");
 
       // Watch for asset changes
-      let ctx = await assets.run({ root: dest, argv: ["--watch"] });
+      let ctx = await assets.run({ root: dest, argv: ["--path=app --watch"] });
 
       await fs.writeFile(entryPoint, "console.log('Hello, Watch!');");
 

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -114,14 +114,14 @@ describe("hanami-assets", () => {
   });
 
   test("generates SRI", async () => {
-    const entryPoint1 = path.join(dest, "app/assets/js/app.js");
-    await fs.writeFile(entryPoint1, "console.log('Hello, World!');");
+    const appEntryPoint = path.join(dest, "app/assets/js/app.js");
+    await fs.writeFile(appEntryPoint, "console.log('Hello, World!');");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app", "--sri=sha256,sha384,sha512"] });
+    await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets", "--sri=sha256,sha384,sha512"] });
 
     // Read and parse the manifest file
-    const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
+    const manifestContent = await fs.readFile(path.join(dest, "public/assets/assets.json"), "utf-8");
     const manifest = JSON.parse(manifestContent);
 
     // Check if the manifest contains the correct file paths

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -64,7 +64,10 @@ describe("hanami-assets", () => {
     expect(manifestExists).toBe(true);
 
     // Read and parse the manifest file
-    const manifestContent = await fs.readFile(path.join(dest, "public/assets/assets.json"), "utf-8");
+    const manifestContent = await fs.readFile(
+      path.join(dest, "public/assets/assets.json"),
+      "utf-8",
+    );
     const manifest = JSON.parse(manifestContent);
 
     // Check if the manifest contains the correct file paths
@@ -107,7 +110,10 @@ describe("hanami-assets", () => {
     expect(manifestExists).toBe(true);
 
     // Read and parse the manifest file
-    const manifestContent = await fs.readFile(path.join(dest, "public/assets/admin/assets.json"), "utf-8");
+    const manifestContent = await fs.readFile(
+      path.join(dest, "public/assets/admin/assets.json"),
+      "utf-8",
+    );
     const manifest = JSON.parse(manifestContent);
 
     // Check if the manifest contains the correct file paths
@@ -129,10 +135,16 @@ describe("hanami-assets", () => {
     await fs.writeFile(appEntryPoint, "console.log('Hello, World!');");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets", "--sri=sha256,sha384,sha512"] });
+    await assets.run({
+      root: dest,
+      argv: ["--path=app", "--target=public/assets", "--sri=sha256,sha384,sha512"],
+    });
 
     // Read and parse the manifest file
-    const manifestContent = await fs.readFile(path.join(dest, "public/assets/assets.json"), "utf-8");
+    const manifestContent = await fs.readFile(
+      path.join(dest, "public/assets/assets.json"),
+      "utf-8",
+    );
     const manifest = JSON.parse(manifestContent);
 
     // Check if the manifest contains the correct file paths
@@ -165,7 +177,10 @@ describe("hanami-assets", () => {
       const imageAsset = path.join(dest, "public", "assets", "background.jpg");
 
       // Watch for asset changes
-      let ctx = await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets", "--watch"] });
+      let ctx = await assets.run({
+        root: dest,
+        argv: ["--path=app", "--target=public/assets", "--watch"],
+      });
 
       await fs.writeFile(entryPoint, "console.log('Hello, Watch!');");
 
@@ -204,7 +219,10 @@ describe("hanami-assets", () => {
       expect(manifestExists).toBe(true);
 
       // Read and parse the manifest file
-      const manifestContent = await fs.readFile(path.join(dest, "public/assets/assets.json"), "utf-8");
+      const manifestContent = await fs.readFile(
+        path.join(dest, "public/assets/assets.json"),
+        "utf-8",
+      );
       const manifest = JSON.parse(manifestContent);
 
       expect(manifest["background.jpg"]).toEqual({

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -44,7 +44,7 @@ describe("hanami-assets", () => {
     await fs.writeFile(entryPoint3, "console.log('Hello, Metrics!');");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app"] });
+    await assets.run({ root: dest, argv: ["--path=app", "--target=public/assets"] });
 
     // FIXME: this path should take into account the file hashing in the file name
     const appAsset = globSync(path.join("public/assets/app-*.js"))[0];

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -26,7 +26,7 @@ async function createTestEnvironment() {
 // Helper function to clean up the test environment
 async function cleanTestEnvironment() {
   process.chdir(originalWorkingDir);
-  // await fs.remove(dest); // Comment this line to manually inspect precompile results
+  await fs.remove(dest); // Comment this line to manually inspect precompile results
 }
 
 describe("hanami-assets", () => {

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -19,7 +19,6 @@ async function createTestEnvironment() {
   await fs.ensureDir(path.join(dest, "slices/admin/assets/fonts"));
   await fs.ensureDir(path.join(dest, "public"));
 
-  console.log(dest);
   process.chdir(dest);
 }
 

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -87,7 +87,7 @@ describe("hanami-assets", () => {
     await fs.writeFile(entryPoint1, "console.log('Hello, World!');");
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app --sri=sha256,sha384,sha512"] });
+    await assets.run({ root: dest, argv: ["--path=app", "--sri=sha256,sha384,sha512"] });
 
     // Read and parse the manifest file
     const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
@@ -110,7 +110,7 @@ describe("hanami-assets", () => {
     fs.copySync(path.join(__dirname, "fixtures", "todo"), dest);
 
     // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app --sri=sha384"] });
+    await assets.run({ root: dest, argv: ["--path=app", "--sri=sha384"] });
 
     // Read and parse the manifest file
     const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
@@ -170,7 +170,7 @@ describe("hanami-assets", () => {
       const imageAsset = path.join(dest, "public", "assets", "background.jpg");
 
       // Watch for asset changes
-      let ctx = await assets.run({ root: dest, argv: ["--path=app --watch"] });
+      let ctx = await assets.run({ root: dest, argv: ["--path=app", "--watch"] });
 
       await fs.writeFile(entryPoint, "console.log('Hello, Watch!');");
 

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -188,7 +188,7 @@ describe("hanami-assets", () => {
         url: "/assets/app-6PW7FGD5.js",
       },
     });
-  })
+  });
 
   test("handles TypeScript", async () => {
     const entryPoint1 = path.join(dest, "app/assets/js/app.ts");
@@ -223,7 +223,7 @@ describe("hanami-assets", () => {
         url: "/assets/nested/app-5VHYTKP2.js",
       },
     });
-  })
+  });
 
   test(
     "watch",

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -13,9 +13,10 @@ async function createTestEnvironment() {
   // Create temporary directories
   await fs.ensureDir(path.join(dest, "app/assets/js"));
   await fs.ensureDir(path.join(dest, "app/assets/images/nested"));
+  await fs.ensureDir(path.join(dest, "app/assets/fonts"));
   await fs.ensureDir(path.join(dest, "slices/admin/assets/js"));
   await fs.ensureDir(path.join(dest, "slices/admin/assets/images/nested"));
-  await fs.ensureDir(path.join(dest, "slices/metrics/assets/js"));
+  await fs.ensureDir(path.join(dest, "slices/admin/assets/fonts"));
   await fs.ensureDir(path.join(dest, "public"));
 
   console.log(dest);
@@ -42,7 +43,9 @@ describe("hanami-assets", () => {
     const appEntryPoint = path.join(dest, "app/assets/js/app.js");
     await fs.writeFile(appEntryPoint, "console.log('Hello, World!');");
     const appImage = path.join(dest, "app/assets/images/nested/app-image.jpg");
-    await fs.writeFile(appImage, "");
+    await fs.writeFile(appImage, "app-image");
+    const appFont = path.join(dest, "app/assets/fonts/app-font.otf");
+    await fs.writeFile(appFont, "app-font");
 
     const sliceEntryPoint = path.join(dest, "slices/admin/assets/js/app.js");
     await fs.writeFile(sliceEntryPoint, "console.log('Hello, Admin!');");
@@ -66,11 +69,14 @@ describe("hanami-assets", () => {
 
     // Check if the manifest contains the correct file paths
     expect(manifest).toEqual({
+      "app-font.otf": {
+        url: "/assets/app-font-E47AB73F.otf",
+      },
       "app.js": {
         url: "/assets/app-JLSTK5SN.js",
       },
       "nested/app-image.jpg": {
-        url: "/assets/nested/app-image-E3B0C442.jpg",
+        url: "/assets/nested/app-image-C6CAD725.jpg",
       },
     });
   });
@@ -85,7 +91,9 @@ describe("hanami-assets", () => {
     const sliceEntryPoint = path.join(dest, "slices/admin/assets/js/app.js");
     await fs.writeFile(sliceEntryPoint, "console.log('Hello, Admin!');");
     const sliceImage = path.join(dest, "slices/admin/assets/images/nested/slice-image.jpg");
-    await fs.writeFile(sliceImage, "");
+    await fs.writeFile(sliceImage, "slice-image");
+    const sliceFont = path.join(dest, "slices/admin/assets/fonts/slice-font.otf");
+    await fs.writeFile(sliceFont, "slice-font");
 
     // Compile assets
     await assets.run({ root: dest, argv: ["--path=slices/admin", "--target=public/assets/admin"] });
@@ -108,7 +116,10 @@ describe("hanami-assets", () => {
         url: "/assets/admin/app-ITGLRDE7.js",
       },
       "nested/slice-image.jpg": {
-        url: "/assets/admin/nested/slice-image-E3B0C442.jpg",
+        url: "/assets/admin/nested/slice-image-4951F7C9.jpg",
+      },
+      "slice-font.otf": {
+        url: "/assets/admin/slice-font-826F93B7.otf",
       },
     });
   });

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -148,53 +148,6 @@ describe("hanami-assets", () => {
     });
   });
 
-  test("Full app", async () => {
-    fs.copySync(path.join(__dirname, "fixtures", "todo"), dest);
-
-    // Compile assets
-    await assets.run({ root: dest, argv: ["--path=app", "--sri=sha384"] });
-
-    // Read and parse the manifest file
-    const manifestContent = await fs.readFile(path.join(dest, "public/assets.json"), "utf-8");
-    const manifest = JSON.parse(manifestContent);
-
-    // Check if the manifest contains the correct file paths
-    expect(manifest).toEqual({
-      "app.js": {
-        url: "/assets/app-YRYN3NGE.js",
-        sri: ["sha384-WAsFKE/RcOorRHTXmdRD8gxW+IxxfzKHbRgzcCuhFDC5StKi+6T+AawxcUmuv8Z5"],
-      },
-      "background.jpg": {
-        url: "/assets/background-UU2XY655.jpg",
-        sri: ["sha384-M7QyKTUfzyVWNC4FoMYq0ypu7LDifAYWEtXRT5d6M3Prpau9t5wavW1216HhvCJc"],
-      },
-      "app.css": {
-        url: "/assets/app-4HPGUYGF.css",
-        sri: ["sha384-KsEObWWMvw+PouA5LgKpXohYpsOO4h9dL9pv7LwznkIg83/n1gkJo+S/oU/9Qb8Q"],
-      },
-      "login/app.js": {
-        url: "/assets/login/app-I4563JRL.js",
-        sri: ["sha384-z0TVeAyYeMsyiCnAqNu/OYs+IxvLwkTocy2uchAChAHmXaV68xYonUUzn1wJ4myH"],
-      },
-      "admin/app.js": {
-        url: "/assets/admin/app-H646WNEB.js",
-        sri: ["sha384-noZH9am6sCla+CnG7l+IGxBlTqo68Wz891fhqfIF1U2kgafUrRzZewAt0yA6jl15"],
-      },
-      "font.otf": {
-        url: "/assets/font-E1A70B27.otf",
-        sri: ["sha384-Lpm/oUsCQkOg41WyENyyB1zjaX/FB522VWlU44JKakwzwBxvu11le0ILkiPsR73K"],
-      },
-      "logo.png": {
-        url: "/assets/logo-C1EF77E4.png",
-        sri: ["sha384-7q5x+ZjZrCoWwyV0BTyc8HUPf1xr+n9l77gwxmwywPWSe0PtopZj1T8NTUPFo0FI"],
-      },
-      "nested/image.jpg": {
-        url: "/assets/nested/image-83509E65.jpg",
-        sri: ["sha384-M7QyKTUfzyVWNC4FoMYq0ypu7LDifAYWEtXRT5d6M3Prpau9t5wavW1216HhvCJc"],
-      },
-    });
-  });
-
   test(
     "watch",
     async () => {


### PR DESCRIPTION
Update our esbuild wrapper to compile a single assets directory at a time.

Previously, we crawled the entire app structure to find all assets directories (within the app and slices) and processed them all at once. This had some downsides:

- It made our esbuild wrapper and plugin complicated.
- It meant that we had to take extra steps to prevent naming conflicts for assets with the same name in different slices.
- The above also meant that every slice's assets had to be referred to with the slice name as a leading namespace (e.g. "admin/app.js" for an admin slice), which didn't fit well with the idea of slices being fully self-contained.
- In general, it meant we had redundant functionality in JS code (such as locating slices) that already existed in our Ruby code.

By processing a single assets directory at once, we have a much simpler interface with esbuild: we're not pushing it to do things outside its comfort zone. It also means we can eliminate that redundant logic and continue to leverage our Ruby code as the canonical source of knowledge around slices and the overall Hanami app structure.

To process a single directory and output the compiled files into the relevant location, we expect these to be passed as two new arguments when invoking `config/assets.js`:

- `--path`: the path for the app or slice containing the assets to process; e.g. `app` or `slices/admin`
- `--dest`: the directory to putout the compiled files; e.g. `public/assets` or `public/assets/admin` (in the case of the admin slice)

These args will not need to be supplied by the user. Instead, they'll be provided by the `hanami assets compile` and `hanami assets watch` commands, which will determine the slices with assets and then invoke one `config/assets.js` process per slice, along with the relevant CLI arguments. This means the user experience is still simple and streamlined.