### PR TITLE
Set logLevel to “info” when building

### DIFF
--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -75,7 +75,7 @@ export const buildOptions = (root, args) => {
         absWorkingDir: root,
         loader: loader,
         external: externalDirectories(),
-        logLevel: "silent",
+        logLevel: "info",
         minify: true,
         sourcemap: true,
         entryNames: "[dir]/[name]-[hash]",

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -94,7 +94,7 @@ export const buildOptions = (root: string, args: Args): EsbuildOptions => {
     absWorkingDir: root,
     loader: loader,
     external: externalDirectories(),
-    logLevel: "silent",
+    logLevel: "info",
     minify: true,
     sourcemap: true,
     entryNames: "[dir]/[name]-[hash]",


### PR DESCRIPTION
This provides useful output and gives the user feedback that compilation has completed successfully.