### PR TITLE
Allow references to files outside js/ and css/ dirs

### DIFF
--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -29,7 +29,7 @@ const hanamiEsbuild = (options) => {
                 // Copy extra asset files (in dirs besides js/ and css/) into the destination directory
                 const copiedAssets = [];
                 assetDirectories().forEach((pattern) => {
-                    copiedAssets.push(...processAssetDirectory(pattern, loadedFiles, options));
+                    copiedAssets.push(...processAssetDirectory(pattern));
                 });
                 // Add files already bundled by esbuild into the manifest
                 for (const outputFile in outputs) {
@@ -102,7 +102,7 @@ const hanamiEsbuild = (options) => {
                         return [];
                     }
                 }
-                function processAssetDirectory(pattern, loadedFiles, options) {
+                function processAssetDirectory(pattern) {
                     const dirPath = path.dirname(pattern);
                     const files = fs.readdirSync(dirPath, { recursive: true });
                     const assets = [];
@@ -124,7 +124,7 @@ const hanamiEsbuild = (options) => {
                             .relative(dirPath, sourcePath)
                             .replace(path.basename(file.toString()), destFileName));
                         if (fs.lstatSync(sourcePath).isDirectory()) {
-                            assets.push(...processAssetDirectory(destPath, loadedFiles, options));
+                            assets.push(...processAssetDirectory(destPath));
                         }
                         else {
                             copyAsset(sourcePath, destPath);

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -28,8 +28,8 @@ const hanamiEsbuild = (options) => {
                 }
                 // Copy extra asset files (in dirs besides js/ and css/) into the destination directory
                 const copiedAssets = [];
-                assetDirectories().forEach((pattern) => {
-                    copiedAssets.push(...processAssetDirectory(pattern));
+                assetDirectories().forEach((dir) => {
+                    copiedAssets.push(...processAssetDirectory(dir));
                 });
                 // Add files already bundled by esbuild into the manifest
                 for (const outputFile in outputs) {
@@ -95,20 +95,19 @@ const hanamiEsbuild = (options) => {
                             const dirName = dir.split(path.sep).pop();
                             return !excludeDirs.includes(dirName);
                         });
-                        return filteredDirs.map((dir) => path.join(dir, "*"));
+                        return filteredDirs;
                     }
                     catch (err) {
                         console.error("Error listing external directories:", err);
                         return [];
                     }
                 }
-                function processAssetDirectory(pattern) {
-                    const dirPath = path.dirname(pattern);
-                    const files = fs.readdirSync(dirPath, { recursive: true });
+                function processAssetDirectory(assetDir) {
+                    const files = fs.readdirSync(assetDir, { recursive: true });
                     const assets = [];
                     files.forEach((file) => {
-                        const sourcePath = path.join(dirPath, file.toString());
-                        // Skip referenced files
+                        const sourcePath = path.join(assetDir, file.toString());
+                        // Skip files loaded by esbuild; those are added to the manifest separately
                         if (loadedFiles.has(sourcePath)) {
                             return;
                         }
@@ -121,7 +120,7 @@ const hanamiEsbuild = (options) => {
                         const baseName = path.basename(sourcePath, fileExtension);
                         const destFileName = [baseName, fileHash].filter((item) => item !== null).join("-") + fileExtension;
                         const destPath = path.join(options.destDir, path
-                            .relative(dirPath, sourcePath)
+                            .relative(assetDir, sourcePath)
                             .replace(path.basename(file.toString()), destFileName));
                         if (fs.lstatSync(sourcePath).isDirectory()) {
                             assets.push(...processAssetDirectory(destPath));

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -22,7 +22,7 @@ const hanamiEsbuild = (options) => {
             // After build, copy over any non-referenced asset files, and create a manifest.
             build.onEnd(async (result) => {
                 const outputs = result.metafile?.outputs;
-                const assetsManifest = {};
+                const manifest = {};
                 if (typeof outputs === "undefined") {
                     return;
                 }
@@ -68,7 +68,7 @@ const hanamiEsbuild = (options) => {
                             .replace(options.destDir + path.sep, "")
                             .replace(fileHashRegexp, "$2");
                     }
-                    assetsManifest[manifestKey] = prepareAsset(outputFile);
+                    manifest[manifestKey] = prepareAsset(outputFile);
                 }
                 // Add copied assets into the manifest
                 for (const copiedAsset of copiedAssets) {
@@ -80,10 +80,10 @@ const hanamiEsbuild = (options) => {
                     var sourceUrl = copiedAsset.sourcePath.replace(assetsSourcePath + path.sep, "");
                     // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
                     sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
-                    assetsManifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
+                    manifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
                 }
                 // Write assets manifest to the destination directory
-                await fs.writeJson(manifestPath, assetsManifest, { spaces: 2 });
+                await fs.writeJson(manifestPath, manifest, { spaces: 2 });
                 //
                 // Helper functions
                 //

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -108,13 +108,45 @@ const hanamiEsbuild = (options) => {
                 }
                 // Add files already bundled by esbuild into the manifest
                 const fileHashRegexp = /(-[A-Z0-9]{8})(\.\S+)$/;
-                for (const outputFile of outputFiles(outputs)) {
-                    // Convert "public/assets/app-2TLUHCQ6.js" to "app.js"
-                    let sourceUrl = outputFile
-                        .replace(options.destDir + "/", "")
-                        .replace(fileHashRegexp, "$2");
+                const sourceAssetsDir = path.join(options.sourceDir, assetsDirName); // TODO make better
+                for (const outputFile in outputs) {
+                    // Ignore esbuild's generated map files
+                    if (outputFile.endsWith(".map")) {
+                        continue;
+                    }
+                    const outputAttrs = outputs[outputFile];
+                    const inputFiles = Object.keys(outputAttrs.inputs);
+                    // Determine the manifest key for the esbuild output file
+                    let manifestKey;
+                    if (!(outputFile.endsWith(".js") || outputFile.endsWith(".css")) &&
+                        inputFiles.length == 1 &&
+                        inputFiles[0].startsWith(sourceAssetsDir + path.sep)) {
+                        // A non-JS/CSS output with a single input will be an asset file that has been been
+                        // referenced from JS/CSS.
+                        //
+                        // In this case, preserve the original input file's path in the manifest key, so it
+                        // matches any other files copied over from that path via processAssetDirectory.
+                        //
+                        // For example, given the input file "app/assets/images/icons/some-icon.png", return a
+                        // manifest key of "icons/some-icon.png".
+                        manifestKey = inputFiles[0]
+                            .substring(sourceAssetsDir.length + 1) // + 1 to account for the sep
+                            .split(path.sep)
+                            .slice(1)
+                            .join(path.sep);
+                    }
+                    else {
+                        // For all other outputs, determine the manifest key based on the output file name,
+                        // stripping away the hash suffix added by esbuild.
+                        //
+                        // For example, given the output "public/assets/app-2TLUHCQ6.js", return an manifest
+                        // key of "app.js".
+                        manifestKey = outputFile
+                            .replace(options.destDir + path.sep, "")
+                            .replace(fileHashRegexp, "$2");
+                    }
                     const destinationUrl = calulateDestinationUrl(outputFile);
-                    assetsManifest[sourceUrl] = prepareAsset(outputFile, destinationUrl);
+                    assetsManifest[manifestKey] = prepareAsset(outputFile, destinationUrl);
                 }
                 // Add copied assets into the manifest
                 for (const copiedAsset of copiedAssets) {
@@ -131,15 +163,6 @@ const hanamiEsbuild = (options) => {
                 }
                 // Write assets manifest to the destination directory
                 await fs.writeJson(manifestPath, assetsManifest, { spaces: 2 });
-                function outputFiles(esbuildOutputs) {
-                    const outputs = [];
-                    for (const key in esbuildOutputs) {
-                        if (!key.endsWith(".map")) {
-                            outputs.push(key);
-                        }
-                    }
-                    return outputs;
-                }
                 function extraAssetDirectories(basePath) {
                     const assetDirsPattern = [path.join(basePath, assetsDirName, "*")];
                     const excludeDirs = ["js", "css"];

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -11,8 +11,8 @@ const hanamiEsbuild = (options) => {
         setup(build) {
             build.initialOptions.metafile = true;
             const manifestPath = path.join(options.root, options.destDir, "assets.json");
-            const assetsSourcePath = path.join(options.root, options.sourceDir, assetsDirName);
             const assetsSourceDir = path.join(options.sourceDir, assetsDirName);
+            const assetsSourcePath = path.join(options.root, assetsSourceDir);
             // Track files loaded by esbuild so we don't double-process them.
             const loadedFiles = new Set();
             build.onLoad({ filter: /.*/ }, (args) => {

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -33,7 +33,6 @@ const hanamiEsbuild = (options) => {
                 });
                 // Add copied assets into the manifest
                 for (const copiedAsset of copiedAssets) {
-                    // TODO: I wonder if we can skip .map files earlier
                     if (copiedAsset.sourcePath.endsWith(".map")) {
                         continue;
                     }
@@ -45,7 +44,6 @@ const hanamiEsbuild = (options) => {
                 }
                 // Add files already bundled by esbuild into the manifest
                 for (const outputFile in outputs) {
-                    // Ignore esbuild's generated map files
                     if (outputFile.endsWith(".map")) {
                         continue;
                     }

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -38,22 +38,6 @@ const findEntryPoints = (sliceRoot) => {
     });
     return result;
 };
-const findExternalDirectories = (basePath) => {
-    const assetDirsPattern = [path.join(basePath, assetsDirName, "*")];
-    const excludeDirs = ["js", "css"];
-    try {
-        const dirs = globSync(assetDirsPattern, { nodir: false });
-        const filteredDirs = dirs.filter((dir) => {
-            const dirName = dir.split(path.sep).pop();
-            return !excludeDirs.includes(dirName);
-        });
-        return filteredDirs.map((dir) => path.join(dir, "*"));
-    }
-    catch (err) {
-        console.error("Error listing external directories:", err);
-        return [];
-    }
-};
 const commonPluginOptions = (root, args) => {
     return {
         root: root,
@@ -69,7 +53,6 @@ const commonOptions = (root, args, plugin) => {
         outdir: args.dest,
         absWorkingDir: root,
         loader: loader,
-        external: findExternalDirectories(path.join(root, args.path)),
         logLevel: "info",
         entryPoints: findEntryPoints(path.join(root, args.path)),
         plugins: [plugin],

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -57,7 +57,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         // Copy extra asset files (in dirs besides js/ and css/) into the destination directory
         const copiedAssets: CopiedAsset[] = [];
         assetDirectories().forEach((pattern) => {
-          copiedAssets.push(...processAssetDirectory(pattern, loadedFiles, options));
+          copiedAssets.push(...processAssetDirectory(pattern));
         });
 
         // Add files already bundled by esbuild into the manifest
@@ -143,11 +143,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           }
         }
 
-        function processAssetDirectory(
-          pattern: string,
-          loadedFiles: Set<String>,
-          options: PluginOptions,
-        ): CopiedAsset[] {
+        function processAssetDirectory(pattern: string): CopiedAsset[] {
           const dirPath = path.dirname(pattern);
           const files = fs.readdirSync(dirPath, { recursive: true });
           const assets: CopiedAsset[] = [];
@@ -178,7 +174,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
             );
 
             if (fs.lstatSync(sourcePath).isDirectory()) {
-              assets.push(...processAssetDirectory(destPath, loadedFiles, options));
+              assets.push(...processAssetDirectory(destPath));
             } else {
               copyAsset(sourcePath, destPath);
               assets.push({ sourcePath: sourcePath, destPath: destPath });

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -35,8 +35,8 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
       build.initialOptions.metafile = true;
 
       const manifestPath = path.join(options.root, options.destDir, "assets.json");
-      const assetsSourcePath = path.join(options.root, options.sourceDir, assetsDirName);
       const assetsSourceDir = path.join(options.sourceDir, assetsDirName);
+      const assetsSourcePath = path.join(options.root, assetsSourceDir);
 
       // Track files loaded by esbuild so we don't double-process them.
       const loadedFiles = new Set<string>();

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -60,6 +60,21 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           copiedAssets.push(...processAssetDirectory(dir));
         });
 
+        // Add copied assets into the manifest
+        for (const copiedAsset of copiedAssets) {
+          // TODO: I wonder if we can skip .map files earlier
+          if (copiedAsset.sourcePath.endsWith(".map")) {
+            continue;
+          }
+
+          // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
+          var sourceUrl = copiedAsset.sourcePath.replace(assetsSourcePath + path.sep, "");
+          // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
+          sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
+
+          manifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
+        }
+
         // Add files already bundled by esbuild into the manifest
         for (const outputFile in outputs) {
           // Ignore esbuild's generated map files
@@ -102,21 +117,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           }
 
           manifest[manifestKey] = prepareAsset(outputFile);
-        }
-
-        // Add copied assets into the manifest
-        for (const copiedAsset of copiedAssets) {
-          // TODO: I wonder if we can skip .map files earlier
-          if (copiedAsset.sourcePath.endsWith(".map")) {
-            continue;
-          }
-
-          // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
-          var sourceUrl = copiedAsset.sourcePath.replace(assetsSourcePath + path.sep, "");
-          // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
-          sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
-
-          manifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
         }
 
         // Write assets manifest to the destination directory

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -48,7 +48,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
       // After build, copy over any non-referenced asset files, and create a manifest.
       build.onEnd(async (result: BuildResult) => {
         const outputs = result.metafile?.outputs;
-        const assetsManifest: Record<string, Asset> = {};
+        const manifest: Record<string, Asset> = {};
 
         if (typeof outputs === "undefined") {
           return;
@@ -101,7 +101,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
               .replace(fileHashRegexp, "$2");
           }
 
-          assetsManifest[manifestKey] = prepareAsset(outputFile);
+          manifest[manifestKey] = prepareAsset(outputFile);
         }
 
         // Add copied assets into the manifest
@@ -116,11 +116,11 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
           sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
 
-          assetsManifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
+          manifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
         }
 
         // Write assets manifest to the destination directory
-        await fs.writeJson(manifestPath, assetsManifest, { spaces: 2 });
+        await fs.writeJson(manifestPath, manifest, { spaces: 2 });
 
         //
         // Helper functions

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -47,98 +47,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         const outputs = result.metafile?.outputs;
         const assetsManifest: Record<string, Asset> = {};
 
-        const calulateDestinationUrl = (str: string): string => {
-          return normalizeUrl(str).replace(/public/, "");
-        };
-
-        const normalizeUrl = (str: string): string => {
-          return str.replace(/[\\]+/, URL_SEPARATOR);
-        };
-
-        const calculateSubresourceIntegrity = (algorithm: string, path: string): string => {
-          const content = fs.readFileSync(path, "utf8");
-          const hash = crypto.createHash(algorithm).update(content).digest("base64");
-
-          return `${algorithm}-${hash}`;
-        };
-
-        // Inspired by https://github.com/evanw/esbuild/blob/2f2b90a99d626921d25fe6d7d0ca50bd48caa427/internal/bundler/bundler.go#L1057
-        const calculateHash = (hashBytes: Uint8Array, hash: boolean): string | null => {
-          if (!hash) {
-            return null;
-          }
-
-          const result = crypto.createHash("sha256").update(hashBytes).digest("hex");
-
-          return result.slice(0, 8).toUpperCase();
-        };
-
-        // TODO: profile the current implementation vs blindly copying the asset
-        const copyAsset = (srcPath: string, destPath: string): void => {
-          if (fs.existsSync(destPath)) {
-            const srcStat = fs.statSync(srcPath);
-            const destStat = fs.statSync(destPath);
-
-            // File already exists and is up-to-date, skip copying
-            if (srcStat.mtimeMs <= destStat.mtimeMs) {
-              return;
-            }
-          }
-
-          if (!fs.existsSync(path.dirname(destPath))) {
-            fs.mkdirSync(path.dirname(destPath), { recursive: true });
-          }
-
-          fs.copyFileSync(srcPath, destPath);
-
-          return;
-        };
-
-        const processAssetDirectory = (
-          pattern: string,
-          referencedFiles: Set<String>,
-          options: PluginOptions,
-        ): CopiedAsset[] => {
-          const dirPath = path.dirname(pattern);
-          const files = fs.readdirSync(dirPath, { recursive: true });
-          const assets: CopiedAsset[] = [];
-
-          files.forEach((file) => {
-            const sourcePath = path.join(dirPath, file.toString());
-
-            // Skip referenced files
-            if (referencedFiles.has(sourcePath)) {
-              return;
-            }
-
-            // Skip directories and any other non-files
-            if (!fs.statSync(sourcePath).isFile()) {
-              return;
-            }
-
-            const fileHash = calculateHash(fs.readFileSync(sourcePath), options.hash);
-            const fileExtension = path.extname(sourcePath);
-            const baseName = path.basename(sourcePath, fileExtension);
-            const destFileName =
-              [baseName, fileHash].filter((item) => item !== null).join("-") + fileExtension;
-            const destPath = path.join(
-              options.destDir,
-              path
-                .relative(dirPath, sourcePath)
-                .replace(path.basename(file.toString()), destFileName),
-            );
-
-            if (fs.lstatSync(sourcePath).isDirectory()) {
-              assets.push(...processAssetDirectory(destPath, referencedFiles, options));
-            } else {
-              copyAsset(sourcePath, destPath);
-              assets.push({ sourcePath: sourcePath, destPath: destPath });
-            }
-          });
-
-          return assets;
-        };
-
         if (typeof outputs === "undefined") {
           return;
         }
@@ -239,6 +147,10 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         // Write assets manifest to the destination directory
         await fs.writeJson(manifestPath, assetsManifest, { spaces: 2 });
 
+        //
+        // Helper functions
+        //
+
         function extraAssetDirectories(basePath: string): string[] {
           const assetDirsPattern = [path.join(basePath, assetsDirName, "*")];
           const excludeDirs = ["js", "css"];
@@ -255,6 +167,98 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
             console.error("Error listing external directories:", err);
             return [];
           }
+        }
+
+        function calulateDestinationUrl(str: string): string {
+          return normalizeUrl(str).replace(/public/, "");
+        }
+
+        function normalizeUrl(str: string): string {
+          return str.replace(/[\\]+/, URL_SEPARATOR);
+        }
+
+        function calculateSubresourceIntegrity(algorithm: string, path: string): string {
+          const content = fs.readFileSync(path, "utf8");
+          const hash = crypto.createHash(algorithm).update(content).digest("base64");
+
+          return `${algorithm}-${hash}`;
+        }
+
+        // Inspired by https://github.com/evanw/esbuild/blob/2f2b90a99d626921d25fe6d7d0ca50bd48caa427/internal/bundler/bundler.go#L1057
+        function calculateHash(hashBytes: Uint8Array, hash: boolean): string | null {
+          if (!hash) {
+            return null;
+          }
+
+          const result = crypto.createHash("sha256").update(hashBytes).digest("hex");
+
+          return result.slice(0, 8).toUpperCase();
+        }
+
+        function processAssetDirectory(
+          pattern: string,
+          referencedFiles: Set<String>,
+          options: PluginOptions,
+        ): CopiedAsset[] {
+          const dirPath = path.dirname(pattern);
+          const files = fs.readdirSync(dirPath, { recursive: true });
+          const assets: CopiedAsset[] = [];
+
+          files.forEach((file) => {
+            const sourcePath = path.join(dirPath, file.toString());
+
+            // Skip referenced files
+            if (referencedFiles.has(sourcePath)) {
+              return;
+            }
+
+            // Skip directories and any other non-files
+            if (!fs.statSync(sourcePath).isFile()) {
+              return;
+            }
+
+            const fileHash = calculateHash(fs.readFileSync(sourcePath), options.hash);
+            const fileExtension = path.extname(sourcePath);
+            const baseName = path.basename(sourcePath, fileExtension);
+            const destFileName =
+              [baseName, fileHash].filter((item) => item !== null).join("-") + fileExtension;
+            const destPath = path.join(
+              options.destDir,
+              path
+                .relative(dirPath, sourcePath)
+                .replace(path.basename(file.toString()), destFileName),
+            );
+
+            if (fs.lstatSync(sourcePath).isDirectory()) {
+              assets.push(...processAssetDirectory(destPath, referencedFiles, options));
+            } else {
+              copyAsset(sourcePath, destPath);
+              assets.push({ sourcePath: sourcePath, destPath: destPath });
+            }
+          });
+
+          return assets;
+        }
+
+        // TODO: profile the current implementation vs blindly copying the asset
+        function copyAsset(srcPath: string, destPath: string): void {
+          if (fs.existsSync(destPath)) {
+            const srcStat = fs.statSync(srcPath);
+            const destStat = fs.statSync(destPath);
+
+            // File already exists and is up-to-date, skip copying
+            if (srcStat.mtimeMs <= destStat.mtimeMs) {
+              return;
+            }
+          }
+
+          if (!fs.existsSync(path.dirname(destPath))) {
+            fs.mkdirSync(path.dirname(destPath), { recursive: true });
+          }
+
+          fs.copyFileSync(srcPath, destPath);
+
+          return;
         }
       });
     },

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -62,7 +62,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
         // Add copied assets into the manifest
         for (const copiedAsset of copiedAssets) {
-          // TODO: I wonder if we can skip .map files earlier
           if (copiedAsset.sourcePath.endsWith(".map")) {
             continue;
           }
@@ -77,7 +76,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
 
         // Add files already bundled by esbuild into the manifest
         for (const outputFile in outputs) {
-          // Ignore esbuild's generated map files
           if (outputFile.endsWith(".map")) {
             continue;
           }

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -53,24 +53,6 @@ const findEntryPoints = (sliceRoot: string): Record<string, string> => {
   return result;
 };
 
-const findExternalDirectories = (basePath: string): string[] => {
-  const assetDirsPattern = [path.join(basePath, assetsDirName, "*")];
-  const excludeDirs = ["js", "css"];
-
-  try {
-    const dirs = globSync(assetDirsPattern, { nodir: false });
-    const filteredDirs = dirs.filter((dir) => {
-      const dirName = dir.split(path.sep).pop();
-      return !excludeDirs.includes(dirName!);
-    });
-
-    return filteredDirs.map((dir) => path.join(dir, "*"));
-  } catch (err) {
-    console.error("Error listing external directories:", err);
-    return [];
-  }
-};
-
 const commonPluginOptions = (root: string, args: Args): PluginOptions => {
   return {
     root: root,
@@ -87,7 +69,6 @@ const commonOptions = (root: string, args: Args, plugin: Plugin): EsbuildOptions
     outdir: args.dest,
     absWorkingDir: root,
     loader: loader,
-    external: findExternalDirectories(path.join(root, args.path)),
     logLevel: "info",
     entryPoints: findEntryPoints(path.join(root, args.path)),
     plugins: [plugin],

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -134,21 +134,23 @@ describe("hanami-assets", () => {
   test("handles references to files outside js/ and css/ directories", async () => {
     const entryPoint = path.join(dest, "app/assets/js/app.js");
     await fs.writeFile(entryPoint, 'import "../css/app.css";');
+    // const entryPoint2 = path.join(dest, "app/assets/js/nested/app.js");
+    // await fs.writeFile(entryPoint2, "");
     const cssFile = path.join(dest, "app/assets/css/app.css");
     await fs.writeFile(
       cssFile,
-      '@font-face { font-family: "comic-mono"; src: url("../fonts/comic-mono.ttf"); }',
+      '@font-face { font-family: "comic-mono"; src: url("../fonts/comic-mono/comic-mono.ttf"); }',
     );
-    const fontFile = path.join(dest, "app/assets/fonts/comic-mono.ttf");
+    await fs.ensureDir(path.join(dest, "app/assets/fonts/comic-mono"));
+    const fontFile = path.join(dest, "app/assets/fonts/comic-mono/comic-mono.ttf");
     await fs.writeFile(fontFile, "");
 
     await assets.run({ root: dest, argv: ["--path=app", "--dest=public/assets"] });
 
     const entryPointExists = await fs.pathExists(path.join("public/assets/app-6PW7FGD5.js"));
     expect(entryPointExists).toBe(true);
-    const cssExists = await fs.pathExists(path.join("public/assets/app-LI4JR7XG.css"));
+    const cssExists = await fs.pathExists(path.join("public/assets/app-GIY6HCGO.css"));
     expect(cssExists).toBe(true);
-    // NOT comic-mono-E3B0C442.ttf - it is a duplicate; this is what our manual asset copying creates.
     const fontExists = await fs.pathExists(path.join("public/assets/comic-mono-55DNWN2R.ttf"));
     expect(fontExists).toBe(true);
 
@@ -162,11 +164,11 @@ describe("hanami-assets", () => {
       "app.js": {
         url: "/assets/app-6PW7FGD5.js",
       },
-      "comic-mono.ttf": {
+      "comic-mono/comic-mono.ttf": {
         url: "/assets/comic-mono-55DNWN2R.ttf",
       },
       "app.css": {
-        url: "/assets/app-LI4JR7XG.css",
+        url: "/assets/app-GIY6HCGO.css",
       },
     });
   });


### PR DESCRIPTION
Stop marking the directories aside from js/ and css/ as "external". This allows the files inside those other directories to be referenced from within JS/CSS files and properly bundled by esbuild.

This incorporates @krzykamil's (excellent!) suggestion in https://github.com/hanami/assets-js/pull/27, which uses an `onLoad` callback to track referenced files so that we can exclude them from separate handling when we copy over the non-referenced asset files.

Specific changes:

- Stop marking any directories as external (in `esbuild.js`)
- Move `findExternalDirectories` from `esbuild.js` to `esbuild-plugin.js` as `extraAssetDirs` (a more appropriate name now that nothing is marked as external), and call this directly when determining which directories we should manually copy via `processAssetDirectory`.
- Introduce an `onLoad` callback to `esbuild-plugin.js` and use this to track any files that esbuild itself loads.
- Use this to skip already-loaded files inside `processAssetDirectory`, which means there will be no double-processing of the files that are referenced from JS/CSS.
- Then when handling esbuild's outputs (i.e. all the loaded files) to include in the manifest, make sure to use the output's original input filename for the manifest key, to avoid collisions and to keep those manifest keys consistent with non-loaded files that are copied across as part of `processAssetDirectory`.
- Plus a range of other refactors/tidyings

Thanks also to @svoop for the great initial bug report (in #24 as well as the [ensuing forum conversation](https://discourse.hanamirb.org/t/incorrect-paths-after-asset-compile/920))!

Fixes #24.