### PR TITLE
Handle duplicates of external compilations

### DIFF
--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -149,7 +149,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           pattern: string,
           compiledEntryPoints: Record<string, boolean>,
           options: PluginOptions,
-          referencedFiles: Set<string> // Add this parameter
+          referencedFiles: Set<string>
         ): CopiedAsset[] => {
           const dirPath = path.dirname(pattern);
           const files = fs.readdirSync(dirPath, { recursive: true });
@@ -168,7 +168,6 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
               return;
             }
 
-            // Skip if the file is already referenced in CSS/JS
             if (referencedFiles.has(sourcePath)) {
               return;
             }


### PR DESCRIPTION
![image](https://github.com/hanami/assets-js/assets/25006471/3f8668bf-a899-4405-a99e-c713c810ae5d)
Result of compile with fonts nested as on screenshot. My app uses slice assets and no duplicates were created, the test that @timriley wrote does pass.

This is my first experience with TS and the repository so this might be a stupid solution, nevertheless I wanted to have a go at it