### PR TITLE
Fix assets windows

### DIFF
--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -88,7 +88,7 @@ const hanamiEsbuild = (options) => {
                 function assetDirectories() {
                     const excludeDirs = ["js", "css"];
                     try {
-                        const dirs = globSync([path.join(assetsSourcePath, "*")], { nodir: false });
+                        const dirs = globSync([path.join(assetsSourcePath, "*").replaceAll(path.sep, path.posix.sep)], { nodir: false });
                         const filteredDirs = dirs.filter((dir) => {
                             const dirName = dir.split(path.sep).pop();
                             return !excludeDirs.includes(dirName);

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -81,7 +81,7 @@ const hanamiEsbuild = (options) => {
                     manifest[manifestKey] = prepareAsset(outputFile);
                 }
                 // Write assets manifest to the destination directory
-                await fs.writeJson(manifestPath, manifest, { spaces: 2 });
+                await fs.outputJSON(manifestPath, manifest, { spaces: 2 });
                 //
                 // Helper functions
                 //

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -38,6 +38,7 @@ const hanamiEsbuild = (options) => {
                     }
                     // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
                     var sourceUrl = copiedAsset.sourcePath.replace(assetsSourcePath + path.sep, "");
+                    sourceUrl = sourceUrl.replaceAll(path.sep, path.posix.sep);
                     // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
                     sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
                     manifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
@@ -81,7 +82,7 @@ const hanamiEsbuild = (options) => {
                     manifest[manifestKey] = prepareAsset(outputFile);
                 }
                 // Write assets manifest to the destination directory
-                await fs.outputJSON(manifestPath, manifest, { spaces: 2 });
+                await fs.writeJSON(manifestPath, manifest, { spaces: 2 });
                 //
                 // Helper functions
                 //

--- a/dist/esbuild-plugin.js
+++ b/dist/esbuild-plugin.js
@@ -2,7 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import crypto from "node:crypto";
 import { globSync } from "glob";
-const URL_SEPARATOR = "/";
+import { normalizePath } from "./esbuild.js";
 const assetsDirName = "assets";
 const fileHashRegexp = /(-[A-Z0-9]{8})(\.\S+)$/;
 const hanamiEsbuild = (options) => {
@@ -38,9 +38,9 @@ const hanamiEsbuild = (options) => {
                     }
                     // Take the full path of the copied asset and remove everything up to (and including) the "assets/" dir
                     var sourceUrl = copiedAsset.sourcePath.replace(assetsSourcePath + path.sep, "");
-                    sourceUrl = sourceUrl.replaceAll(path.sep, path.posix.sep);
                     // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
                     sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
+                    sourceUrl = normalizePath(sourceUrl);
                     manifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
                 }
                 // Add files already bundled by esbuild into the manifest
@@ -63,11 +63,11 @@ const hanamiEsbuild = (options) => {
                         //
                         // For example, given the input file "app/assets/images/icons/some-icon.png", return a
                         // manifest key of "icons/some-icon.png".
-                        manifestKey = inputFiles[0]
+                        manifestKey = normalizePath(inputFiles[0]
                             .substring(assetsSourceDir.length + 1) // + 1 to account for the sep
                             .split(path.sep)
                             .slice(1)
-                            .join(path.sep);
+                            .join(path.sep));
                     }
                     else {
                         // For all other outputs, determine the manifest key based on the output file name,
@@ -75,21 +75,19 @@ const hanamiEsbuild = (options) => {
                         //
                         // For example, given the output "public/assets/app-2TLUHCQ6.js", return an manifest
                         // key of "app.js".
-                        manifestKey = outputFile
-                            .replace(options.destDir + path.sep, "")
-                            .replace(fileHashRegexp, "$2");
+                        manifestKey = path.basename(outputFile).replace(fileHashRegexp, "$2");
                     }
                     manifest[manifestKey] = prepareAsset(outputFile);
                 }
                 // Write assets manifest to the destination directory
-                await fs.writeJSON(manifestPath, manifest, { spaces: 2 });
+                await fs.outputJSON(manifestPath, manifest, { spaces: 2 });
                 //
                 // Helper functions
                 //
                 function assetDirectories() {
                     const excludeDirs = ["js", "css"];
                     try {
-                        const dirs = globSync([path.join(assetsSourcePath, "*").replaceAll(path.sep, path.posix.sep)], { nodir: false });
+                        const dirs = globSync([normalizePath(path.join(assetsSourcePath, "*"))], { nodir: false });
                         const filteredDirs = dirs.filter((dir) => {
                             const dirName = dir.split(path.sep).pop();
                             return !excludeDirs.includes(dirName);
@@ -159,7 +157,7 @@ const hanamiEsbuild = (options) => {
                     return asset;
                 }
                 function calculateDestinationUrl(str) {
-                    const normalizedUrl = str.replace(/[\\]+/, URL_SEPARATOR);
+                    const normalizedUrl = normalizePath(str);
                     return normalizedUrl.replace(/public/, "");
                 }
                 function calculateSubresourceIntegrity(algorithm, path) {

--- a/dist/esbuild.d.ts
+++ b/dist/esbuild.d.ts
@@ -5,3 +5,4 @@ export interface EsbuildOptions extends Partial<BuildOptions> {
 }
 export declare const buildOptions: (root: string, args: Args) => EsbuildOptions;
 export declare const watchOptions: (root: string, args: Args) => EsbuildOptions;
+export declare const normalizePath: (path: string) => string;

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -25,7 +25,7 @@ const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
 const findEntryPoints = (sliceRoot) => {
     const result = {};
     const entryPoints = globSync([
-        path.join(sliceRoot, assetsDirName, "js", "**", entryPointExtensions),
+        path.join(sliceRoot, assetsDirName, "js", "**", entryPointExtensions).replaceAll(path.sep, path.posix.sep),
     ]);
     entryPoints.forEach((entryPoint) => {
         let entryPointPath = entryPoint.replace(sliceRoot + "/assets/js/", "");

--- a/dist/esbuild.js
+++ b/dist/esbuild.js
@@ -25,7 +25,7 @@ const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
 const findEntryPoints = (sliceRoot) => {
     const result = {};
     const entryPoints = globSync([
-        path.join(sliceRoot, assetsDirName, "js", "**", entryPointExtensions).replaceAll(path.sep, path.posix.sep),
+        normalizePath(path.join(normalizePath(sliceRoot), assetsDirName, "js", "**", entryPointExtensions)),
     ]);
     entryPoints.forEach((entryPoint) => {
         let entryPointPath = entryPoint.replace(sliceRoot + "/assets/js/", "");
@@ -87,4 +87,7 @@ export const watchOptions = (root, args) => {
         sourcemap: false,
     };
     return options;
+};
+export const normalizePath = (path) => {
+    return path.replace(/[\\]+/g, "/");
 };

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -118,7 +118,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         }
 
         // Write assets manifest to the destination directory
-        await fs.writeJson(manifestPath, manifest, { spaces: 2 });
+        await fs.outputJSON(manifestPath, manifest, { spaces: 2 });
 
         //
         // Helper functions

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -3,8 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import crypto from "node:crypto";
 import { globSync } from "glob";
-
-const URL_SEPARATOR = "/";
+import { normalizePath } from "./esbuild.js";
 
 export interface PluginOptions {
   root: string;
@@ -70,7 +69,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           var sourceUrl = copiedAsset.sourcePath.replace(assetsSourcePath + path.sep, "");
           // Then remove the first subdir (e.g. "images/"), since we do not include those in the asset paths
           sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
-
+          sourceUrl = normalizePath(sourceUrl);
           manifest[sourceUrl] = prepareAsset(copiedAsset.destPath);
         }
 
@@ -128,7 +127,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           const excludeDirs = ["js", "css"];
 
           try {
-            const dirs = globSync([path.join(assetsSourcePath, "*")], { nodir: false });
+            const dirs = globSync([normalizePath(path.join(assetsSourcePath, "*"))], { nodir: false });
             const filteredDirs = dirs.filter((dir) => {
               const dirName = dir.split(path.sep).pop();
               return !excludeDirs.includes(dirName!);
@@ -221,7 +220,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         }
 
         function calculateDestinationUrl(str: string): string {
-          const normalizedUrl = str.replace(/[\\]+/, URL_SEPARATOR);
+          const normalizedUrl = normalizePath(str);
           return normalizedUrl.replace(/public/, "");
         }
 

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -97,20 +97,18 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
             //
             // For example, given the input file "app/assets/images/icons/some-icon.png", return a
             // manifest key of "icons/some-icon.png".
-            manifestKey = inputFiles[0]
+            manifestKey = normalizePath(inputFiles[0]
               .substring(assetsSourceDir.length + 1) // + 1 to account for the sep
               .split(path.sep)
               .slice(1)
-              .join(path.sep);
+              .join(path.sep));
           } else {
             // For all other outputs, determine the manifest key based on the output file name,
             // stripping away the hash suffix added by esbuild.
             //
             // For example, given the output "public/assets/app-2TLUHCQ6.js", return an manifest
             // key of "app.js".
-            manifestKey = outputFile
-              .replace(options.destDir + path.sep, "")
-              .replace(fileHashRegexp, "$2");
+            manifestKey = path.basename(outputFile).replace(fileHashRegexp, "$2");
           }
 
           manifest[manifestKey] = prepareAsset(outputFile);

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -35,7 +35,7 @@ const findEntryPoints = (sliceRoot: string): Record<string, string> => {
   const result: Record<string, string> = {};
 
   const entryPoints = globSync([
-    path.join(sliceRoot, assetsDirName, "js", "**", entryPointExtensions),
+    normalizePath(path.join(normalizePath(sliceRoot), assetsDirName, "js", "**", entryPointExtensions)),
   ]);
 
   entryPoints.forEach((entryPoint) => {
@@ -110,3 +110,7 @@ export const watchOptions = (root: string, args: Args): EsbuildOptions => {
 
   return options;
 };
+
+export const normalizePath = (path: string): string => {
+  return path.replace(/[\\]+/g, "/");
+}


### PR DESCRIPTION
this is a fix related to the following conversations:
- https://github.com/hanami/cli/pull/221
- https://github.com/hanami/hanami/issues/1463
- https://github.com/hanami/hanami/issues/1464

**TL;DR**: `hanami dev` and asset compilation doesnt work on windows
(the issue where the conversation (mostly) took place is https://github.com/hanami/hanami/issues/1463)

this is part one of likely a few PR's

----------

`assets.json` was not being created on windows platforms, nor were assets being appropriately built / hashed
this PR includes 2 fixes which gets the process working on windows:

1) we are using the `fs-extra` package's `writeJSON` method to write json files (the manifests).  this does not create directories if they do not already exist.  for some reason this works on *nix systems, but not windows.  the `outputJSON` function _will_ create a directory (by default `public/assets` isnt created during `hanami new`).
https://github.com/jprichardson/node-jsonfile/issues/60

2) file path references were broken all over the place, because turns out `glob.sync` doesnt take anything other than posix format. i introduced a small helper function to convert all paths to use the appropriate path separator 

`hanami assets compile` now appropriately creates all asset files correctly (although `hanami dev` and `hanami assets watch` still aren't working -> thats a separate issue and a separate incoming PR on a diff repo :) )

please lmk what you think!