### PR TITLE
Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# assets-js
+
+esbuild plugin for Hanami assets
+
+## Status
+
+[![CI](https://github.com/hanami/assets-js/actions/workflows/ci.yml/badge.svg)](https://github.com/hanami/assets-js/actions?query=workflow%3Aci+branch%3Amain)
+
+## Contact
+
+* Home page: https://hanamirb.org
+* Guides: https://guides.hanamirb.org
+* Community: https://hanamirb.org/community
+
+## Testing
+
+Install the Node packages:
+
+```
+npm install
+```
+
+And run the [Jest test suite](https://jestjs.io/):
+
+```
+npm test
+```
+
+To use `debugger` breakpoints in the tests, open `chrome://inspect` with any Chrome-based browser and click on "Open dedicated DevTools for Node" to open a debugger window. Then:
+
+```
+npm run test:debug
+```
+
+## Versioning
+
+__assets-js__ uses [Semantic Versioning 2.0.0](http://semver.org)
+
+## Contributing
+
+1. Fork it (https://github.com/hanami/assets-js/fork)
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Copyright
+
+Copyright © 2014–2025 Hanami Team – Released under MIT License


### PR DESCRIPTION
This repo lacks a README, so here it is.

One suggestion:

The "Contact" section in all READMEs is quite big and every change (like from http to https) requires commits to all repos. How about stripping it to:

```
* Home page: https://hanamirb.org
* Guides: https://guides.hanamirb.org
* Community: https://hanamirb.org/community
```

Mailing list, forum and chat (old and outdated anyway) are present on the linked community page which should be more than enough.

And as there's a new web site in the works: Will the URLs for the guides and community pages change? Maybe they could be stream lined to both look like `guides.hanamirb.org` or `hanamirb.org/guides`?