### PR TITLE
Include assets that were not previously processed

### DIFF
--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -125,16 +125,8 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         //
 
         function assetDirectories(): string[] {
-          const excludeDirs = ["js", "css"];
-
           try {
-            const dirs = globSync([path.join(assetsSourcePath, "*")], { nodir: false });
-            const filteredDirs = dirs.filter((dir) => {
-              const dirName = dir.split(path.sep).pop();
-              return !excludeDirs.includes(dirName!);
-            });
-
-            return filteredDirs;
+            return globSync([path.join(assetsSourcePath, "*")], { nodir: false });
           } catch (err) {
             console.error("Error listing external directories:", err);
             return [];
@@ -170,12 +162,8 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
                 .replace(path.basename(file.toString()), destFileName),
             );
 
-            if (fs.lstatSync(sourcePath).isDirectory()) {
-              assets.push(...processAssetDirectory(destPath));
-            } else {
-              copyAsset(sourcePath, destPath);
-              assets.push({ sourcePath: sourcePath, destPath: destPath });
-            }
+            copyAsset(sourcePath, destPath);
+            assets.push({ sourcePath: sourcePath, destPath: destPath });
           });
 
           return assets;


### PR DESCRIPTION
:cherry_blossom: hi all! :cherry_blossom: 

a user on [Discord](https://discordapp.com/channels/1339005121303941210/1393319526174687382) discovered a bug with assets that are included in the `js/` and `css/` directories, but were still not being bundled.

by default, esbuild takes an 'entry point' (`app.js`) and then discovers files via imports.  if, for example, someone would like to have a javascript file included in only a single page, they could omit this file from being imported to `app.js`, and refer to that file directly in the template that needed it. if the user placed said javascript file under the appropriately named `js/` directory, currently this file would _not_ be included in the `assets.json` file. esbuild would be unable to discover it from its entry point, and while  we _do_ have code to copy over assets missed by esbuild, but are ignoring any straggler files within the `js/` and `css/` directories.  this PR remedies this issue.

there is a second bonus clean up included in this PR. in the `processAssetDirectory` function, we are early returning if our currently processed 'file' is not a 'file' (e.g. directory).  towards the bottom of the function, we were re-checking the currently processing 'file' to see if it _was_ a directory, intending to recursively process said directories.  this condition would never be met because of the above aforementioned 'return if this is not a file' guard.  additionally, the recursive behavior is already achieved by passing the `{ recursive: true }` option to `readdirSync`. since this is not technically in-scope of the fix, please let me know i can open a second PR for it :slightly_smiling_face: 

thank you!

