### PR TITLE
Add prepare script so dist is built on git-URL installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
+    "prepare": "npm run clean && npm run build",
     "prepack": "npm run clean && npm run build",
     "test": "jest"
   },


### PR DESCRIPTION
Clean up for #43

Those changes were causing CI on hanami/hanami main to fail: https://github.com/hanami/hanami/actions/runs/24621429635

I *think* this should fix it? This is outside of my wheelhouse, but I'm reading that "prepare" is for git-url installs and "prepack" is before publishing.

Here's a PR for hanami/hanami that uses this branch, which appears to validate that getting this into main will fix this issue: https://github.com/hanami/hanami/pull/1581