### PR TITLE
Watch for changes to static files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "hanami-assets",
-  "version": "2.3.1",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hanami-assets",
-      "version": "2.3.1",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
+        "chokidar": "^4.0.1",
         "esbuild": "^0.25.1",
         "fs-extra": "^11.3.0",
         "glob": "^13.0.6"
@@ -27,6 +28,9 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/hanami"
@@ -1881,6 +1885,21 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ci-info": {
@@ -3950,6 +3969,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
+    "chokidar": "^4.0.1",
     "esbuild": "^0.25.1",
     "fs-extra": "^11.3.0",
     "glob": "^13.0.6"

--- a/src/esbuild-plugin.ts
+++ b/src/esbuild-plugin.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra";
 import path from "path";
 import crypto from "node:crypto";
 import { globSync } from "glob";
+import chokidar, { FSWatcher } from "chokidar";
 
 const URL_SEPARATOR = "/";
 
@@ -12,6 +13,7 @@ export interface PluginOptions {
   destDir: string;
   sriAlgorithms: Array<string>;
   hash: boolean;
+  watch: boolean;
 }
 
 interface Asset {
@@ -27,7 +29,106 @@ interface CopiedAsset {
 const assetsDirName = "assets";
 const fileHashRegexp = /(-[A-Z0-9]{8})(\.\S+)$/;
 
+// ManifestManager serializes manifest reads and writes through a promise queue and writes
+// atomically (tmp file + rename), so the esbuild onEnd writer and the chokidar handlers can't race
+// on assets.json.
+class ManifestManager {
+  private manifestPath: string;
+  private queue: Promise<any> = Promise.resolve();
+
+  constructor(manifestPath: string) {
+    this.manifestPath = manifestPath;
+  }
+
+  // Execute an operation with exclusive access to the manifest.
+  private async enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const currentQueue = this.queue;
+    let resolver: (value: T) => void;
+    let rejecter: (error: any) => void;
+
+    const promise = new Promise<T>((resolve, reject) => {
+      resolver = resolve;
+      rejecter = reject;
+    });
+
+    this.queue = currentQueue.then(
+      async () => {
+        try {
+          const result = await operation();
+          resolver(result);
+          return result;
+        } catch (err) {
+          rejecter(err);
+          throw err;
+        }
+      },
+      async (err) => {
+        rejecter(err);
+        throw err;
+      },
+    );
+
+    return promise;
+  }
+
+  async read(): Promise<Record<string, Asset>> {
+    return this.enqueue(async () => {
+      try {
+        return await fs.readJSON(this.manifestPath);
+      } catch (err) {
+        return {};
+      }
+    });
+  }
+
+  async write(manifest: Record<string, Asset>): Promise<void> {
+    return this.enqueue(async () => {
+      const tempPath = `${this.manifestPath}.tmp`;
+      await fs.writeJSON(tempPath, manifest, { spaces: 2 });
+      await fs.rename(tempPath, this.manifestPath);
+    });
+  }
+
+  async updateEntry(key: string, value: Asset): Promise<void> {
+    return this.enqueue(async () => {
+      const manifest = await this.readUnsafe();
+      manifest[key] = value;
+      await this.writeUnsafe(manifest);
+    });
+  }
+
+  async removeEntry(key: string): Promise<void> {
+    return this.enqueue(async () => {
+      const manifest = await this.readUnsafe();
+      if (manifest[key]) {
+        delete manifest[key];
+        await this.writeUnsafe(manifest);
+      }
+    });
+  }
+
+  // readUnsafe and writeUnsafe skip the queue; only call from inside an enqueue() block that
+  // already holds exclusive access.
+  private async readUnsafe(): Promise<Record<string, Asset>> {
+    try {
+      return await fs.readJSON(this.manifestPath);
+    } catch (err) {
+      return {};
+    }
+  }
+
+  private async writeUnsafe(manifest: Record<string, Asset>): Promise<void> {
+    const tempPath = `${this.manifestPath}.tmp`;
+    await fs.writeJSON(tempPath, manifest, { spaces: 2 });
+    await fs.rename(tempPath, this.manifestPath);
+  }
+}
+
 const hanamiEsbuild = (options: PluginOptions): Plugin => {
+  let watcher: FSWatcher | null = null;
+  let isFirstBuild = true;
+  let manifestManager: ManifestManager;
+
   return {
     name: "hanami-esbuild",
 
@@ -37,6 +138,8 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
       const manifestPath = path.join(options.root, options.destDir, "assets.json");
       const assetsSourceDir = path.join(options.sourceDir, assetsDirName);
       const assetsSourcePath = path.join(options.root, assetsSourceDir);
+
+      manifestManager = new ManifestManager(manifestPath);
 
       // Track files loaded by esbuild so we don't double-process them.
       const loadedFiles = new Set<string>();
@@ -48,17 +151,27 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
       // After build, copy over any non-referenced asset files, and create a manifest.
       build.onEnd(async (result: BuildResult) => {
         const outputs = result.metafile?.outputs;
-        const manifest: Record<string, Asset> = {};
 
         if (typeof outputs === "undefined") {
           return;
         }
 
-        // Copy extra asset files (in dirs besides js/ and css/) into the destination directory
+        // In watch mode after first build, preserve existing static asset entries.
+        let manifest: Record<string, Asset> = {};
+        if (options.watch && !isFirstBuild) {
+          manifest = await manifestManager.read();
+        }
+
+        // Copy extra asset files (in dirs besides js/ and css/) into the destination directory.
+        //
+        // In watch mode, only process all static assets on the first build. Subsequent changes are
+        // handled by the chokidar watcher below.
         const copiedAssets: CopiedAsset[] = [];
-        assetDirectories().forEach((dir) => {
-          copiedAssets.push(...processAssetDirectory(dir));
-        });
+        if (!options.watch || isFirstBuild) {
+          assetDirectories().forEach((dir) => {
+            copiedAssets.push(...processAssetDirectory(dir));
+          });
+        }
 
         // Add copied assets into the manifest
         for (const copiedAsset of copiedAssets) {
@@ -118,7 +231,7 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
         }
 
         // Write assets manifest to the destination directory
-        await fs.writeJson(manifestPath, manifest, { spaces: 2 });
+        await manifestManager.write(manifest);
 
         //
         // Helper functions
@@ -241,6 +354,110 @@ const hanamiEsbuild = (options: PluginOptions): Plugin => {
           const result = crypto.createHash("sha256").update(hashBytes).digest("hex");
 
           return result.slice(0, 8).toUpperCase();
+        }
+
+        // Set up file watcher for static assets in watch mode.
+        if (options.watch && !watcher) {
+          const assetDirs = assetDirectories();
+
+          if (assetDirs.length > 0) {
+            watcher = chokidar.watch(assetDirs, {
+              cwd: options.root,
+              ignoreInitial: true,
+              persistent: true,
+            });
+
+            watcher.on("add", (filePath: string) => {
+              const fullPath = path.join(options.root, filePath);
+              processWatchedFile(fullPath);
+            });
+
+            watcher.on("change", (filePath: string) => {
+              const fullPath = path.join(options.root, filePath);
+              processWatchedFile(fullPath);
+            });
+
+            watcher.on("unlink", (filePath: string) => {
+              const fullPath = path.join(options.root, filePath);
+              removeWatchedFile(fullPath);
+            });
+
+            console.log("[hanami-esbuild] Watching for static asset changes...");
+          }
+
+          isFirstBuild = false;
+        }
+
+        // Copy a static asset that was added or changed during watch into the destination directory
+        // and refresh its entry in the manifest.
+        async function processWatchedFile(filePath: string): Promise<void> {
+          const assetDirs = assetDirectories();
+          const matchedDir = assetDirs.find((dir) => filePath.startsWith(dir));
+
+          if (!matchedDir || loadedFiles.has(filePath)) {
+            return;
+          }
+
+          if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+            return;
+          }
+
+          // Assumes options.hash is false. If we later want watch mode to support hashed filenames,
+          // this needs to mirror processAssetDirectory's hash-and-rename logic.
+          const destPath = path.join(options.destDir, path.relative(matchedDir, filePath));
+          copyAsset(filePath, destPath);
+
+          try {
+            let sourceUrl = filePath.replace(assetsSourcePath + path.sep, "");
+            sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
+            const asset = prepareAsset(destPath);
+            await manifestManager.updateEntry(sourceUrl, asset);
+            console.log(`[hanami-esbuild] Updated asset: ${sourceUrl}`);
+          } catch (err) {
+            console.error(`[hanami-esbuild] Error updating manifest:`, err);
+          }
+        }
+
+        // Remove a static asset's destination file and manifest entry after it was deleted from the
+        // source directory during watch.
+        async function removeWatchedFile(filePath: string): Promise<void> {
+          const assetDirs = assetDirectories();
+          const matchedDir = assetDirs.find((dir) => filePath.startsWith(dir));
+
+          if (!matchedDir || loadedFiles.has(filePath)) {
+            return;
+          }
+
+          try {
+            let sourceUrl = filePath.replace(assetsSourcePath + path.sep, "");
+            sourceUrl = sourceUrl.substring(sourceUrl.indexOf("/") + 1);
+
+            const manifest = await manifestManager.read();
+            if (manifest[sourceUrl]) {
+              const destPath = path.join(
+                options.root,
+                options.destDir,
+                path.relative(matchedDir, filePath),
+              );
+              if (fs.existsSync(destPath)) {
+                fs.removeSync(destPath);
+              }
+
+              await manifestManager.removeEntry(sourceUrl);
+              console.log(`[hanami-esbuild] Removed asset: ${sourceUrl}`);
+            }
+          } catch (err) {
+            console.error(`[hanami-esbuild] Error removing asset:`, err);
+          }
+        }
+      });
+
+      build.onDispose(() => {
+        if (watcher) {
+          watcher.close().catch((err) => {
+            console.error("[hanami-esbuild] Error closing watcher:", err);
+          });
+          watcher = null;
         }
       });
     },

--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -62,6 +62,7 @@ const commonPluginOptions = (root: string, args: Args): PluginOptions => {
     destDir: args.dest,
     hash: true,
     sriAlgorithms: [],
+    watch: false,
   };
 };
 
@@ -98,6 +99,7 @@ export const watchOptions = (root: string, args: Args): EsbuildOptions => {
   const pluginOptions: PluginOptions = {
     ...commonPluginOptions(root, args),
     hash: false,
+    watch: true,
   };
   const plugin = esbuildPlugin(pluginOptions);
 

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -362,4 +362,195 @@ describe("hanami-assets", () => {
     },
     watchTimeout + 1000,
   );
+
+  test(
+    "watch: adds a new static asset created after the watcher starts",
+    async () => {
+      const entryPoint = path.join(dest, "app/assets/js/app.js");
+      await fs.writeFile(entryPoint, "console.log('Hello, World!');");
+
+      const ctx = await assets.run({
+        root: dest,
+        argv: ["--path=app", "--dest=public/assets", "--watch"],
+      });
+
+      try {
+        // Wait for the first build to complete and the watcher to be set up.
+        await waitForManifest(dest, (m) => Boolean(m["app.js"]));
+
+        const newImage = path.join(dest, "app/assets/images/added.jpg");
+        await fs.writeFile(newImage, "added-image");
+
+        await waitForManifest(dest, (m) => Boolean(m["added.jpg"]));
+
+        const manifest = readManifest(dest);
+        expect(manifest["added.jpg"]).toEqual({ url: "/assets/added.jpg" });
+
+        const copied = path.join(dest, "public/assets/added.jpg");
+        expect(fs.existsSync(copied)).toBe(true);
+        expect(await fs.readFile(copied, "utf-8")).toBe("added-image");
+      } finally {
+        await ctx!.dispose();
+      }
+    },
+    watchTimeout + 1000,
+  );
+
+  test(
+    "watch: refreshes a static asset modified after the watcher starts",
+    async () => {
+      const entryPoint = path.join(dest, "app/assets/js/app.js");
+      await fs.writeFile(entryPoint, "console.log('Hello, World!');");
+
+      const image = path.join(dest, "app/assets/images/logo.jpg");
+      await fs.writeFile(image, "original");
+
+      const ctx = await assets.run({
+        root: dest,
+        argv: ["--path=app", "--dest=public/assets", "--watch"],
+      });
+
+      try {
+        await waitForManifest(dest, (m) => Boolean(m["logo.jpg"]));
+
+        // Sanity-check the first-build copy.
+        const copied = path.join(dest, "public/assets/logo.jpg");
+        expect(await fs.readFile(copied, "utf-8")).toBe("original");
+
+        await fs.writeFile(image, "updated");
+
+        await waitFor(async () => (await fs.readFile(copied, "utf-8")) === "updated");
+
+        const manifest = readManifest(dest);
+        expect(manifest["logo.jpg"]).toEqual({ url: "/assets/logo.jpg" });
+      } finally {
+        await ctx!.dispose();
+      }
+    },
+    watchTimeout + 1000,
+  );
+
+  test(
+    "watch: removes a static asset deleted after the watcher starts",
+    async () => {
+      const entryPoint = path.join(dest, "app/assets/js/app.js");
+      await fs.writeFile(entryPoint, "console.log('Hello, World!');");
+
+      const image = path.join(dest, "app/assets/images/temp.jpg");
+      await fs.writeFile(image, "temp");
+
+      const ctx = await assets.run({
+        root: dest,
+        argv: ["--path=app", "--dest=public/assets", "--watch"],
+      });
+
+      try {
+        await waitForManifest(dest, (m) => Boolean(m["temp.jpg"]));
+
+        const copied = path.join(dest, "public/assets/temp.jpg");
+        expect(fs.existsSync(copied)).toBe(true);
+
+        await fs.remove(image);
+
+        await waitForManifest(dest, (m) => !m["temp.jpg"]);
+
+        expect(fs.existsSync(copied)).toBe(false);
+      } finally {
+        await ctx!.dispose();
+      }
+    },
+    watchTimeout + 1000,
+  );
+
+  test(
+    "watch: live-reloads static assets under a slice",
+    async () => {
+      const sliceDest = "public/assets/admin";
+      const entryPoint = path.join(dest, "slices/admin/assets/js/app.js");
+      await fs.writeFile(entryPoint, "console.log('Hello, Admin!');");
+
+      const ctx = await assets.run({
+        root: dest,
+        argv: [`--path=slices/admin`, `--dest=${sliceDest}`, "--watch"],
+      });
+
+      try {
+        await waitFor(() => Boolean(readManifest(dest, sliceDest)["app.js"]));
+
+        const newImage = path.join(dest, "slices/admin/assets/images/admin-added.jpg");
+        await fs.writeFile(newImage, "admin-added");
+
+        await waitFor(() => Boolean(readManifest(dest, sliceDest)["admin-added.jpg"]));
+
+        const manifest = readManifest(dest, sliceDest);
+        expect(manifest["admin-added.jpg"]).toEqual({
+          url: "/assets/admin/admin-added.jpg",
+        });
+
+        const copied = path.join(dest, sliceDest, "admin-added.jpg");
+        expect(fs.existsSync(copied)).toBe(true);
+        expect(await fs.readFile(copied, "utf-8")).toBe("admin-added");
+
+        await fs.remove(newImage);
+
+        await waitFor(() => !readManifest(dest, sliceDest)["admin-added.jpg"]);
+        expect(fs.existsSync(copied)).toBe(false);
+      } finally {
+        await ctx!.dispose();
+      }
+    },
+    watchTimeout + 1000,
+  );
+
+  test(
+    "watch: preserves esbuild outputs in the manifest when a static asset changes",
+    async () => {
+      const entryPoint = path.join(dest, "app/assets/js/app.js");
+      await fs.writeFile(entryPoint, "console.log('Hello, World!');");
+
+      const ctx = await assets.run({
+        root: dest,
+        argv: ["--path=app", "--dest=public/assets", "--watch"],
+      });
+
+      try {
+        await waitForManifest(dest, (m) => Boolean(m["app.js"]));
+        const initialJsEntry = readManifest(dest)["app.js"];
+
+        const image = path.join(dest, "app/assets/images/late.jpg");
+        await fs.writeFile(image, "late");
+        await waitForManifest(dest, (m) => Boolean(m["late.jpg"]));
+
+        const manifest = readManifest(dest);
+        expect(manifest["app.js"]).toEqual(initialJsEntry);
+        expect(manifest["late.jpg"]).toEqual({ url: "/assets/late.jpg" });
+      } finally {
+        await ctx!.dispose();
+      }
+    },
+    watchTimeout + 1000,
+  );
 });
+
+function readManifest(root: string, destDir = "public/assets"): Record<string, { url: string }> {
+  const manifestPath = path.join(root, destDir, "assets.json");
+  if (!fs.existsSync(manifestPath)) return {};
+  return fs.readJSONSync(manifestPath);
+}
+
+async function waitForManifest(
+  root: string,
+  predicate: (manifest: Record<string, { url: string }>) => boolean,
+  timeout = 10000,
+): Promise<void> {
+  await waitFor(() => predicate(readManifest(root)), timeout);
+}
+
+async function waitFor(check: () => boolean | Promise<boolean>, timeout = 10000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Condition not met within ${timeout}ms`);
+}


### PR DESCRIPTION
Until now, `--watch` only reacted to inputs esbuild itself bundled — JS, CSS, and assets imported from them. Files under `app/assets/images/`, `app/assets/fonts/`, etc. were copied once on the first build and then ignored, so editing, adding, or removing one of these static assets required restarting the build.

To watch these static assets, add a chokidar watcher over each non-JS/CSS asset directory. On `add` or `change`, copy the file into the destination and update its entry in `assets.json`; on `unlink`, remove the destination file as well as the manifest entry.

On the initial build, still walk the asset tree as before. On subsequent rebuilds, preserve the existing manifest entries instead of rebuilding the manifest from scratch.

Given that the manifest will now be written from chokidar event handlers as well as our existing `onEnd` callback, add a `ManifestManager` to serialize reads and writes through a promise queue, and write atomically (tmp file + rename), so the two writers can't race on `assets.json`.

Resolves #22