### PR TITLE
Bump supported node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 20.x
-          - 21.x
+          - 25.x
+          - 24.x
+          - 22.x
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "keywords": [
     "hanami",


### PR DESCRIPTION
Require Node v22 or later (v22 being the oldest currently-supported LTS version).