### PR TITLE
Detect new entry points in watch mode

### DIFF
--- a/src/esbuild.ts
+++ b/src/esbuild.ts
@@ -31,7 +31,10 @@ const loader: { [ext: string]: Loader } = {
 const assetsDirName = "assets";
 const entryPointExtensions = "app.{js,ts,mjs,mts,tsx,jsx}";
 
-const findEntryPoints = (sliceRoot: string): Record<string, string> => {
+export const entryPointsDir = (sliceRoot: string): string =>
+  path.join(sliceRoot, assetsDirName, "js");
+
+export const findEntryPoints = (sliceRoot: string): Record<string, string> => {
   const result: Record<string, string> = {};
 
   const entryPoints = globSync([

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
 import fs from "fs-extra";
 import path from "path";
 import esbuild, { BuildContext } from "esbuild";
+import chokidar from "chokidar";
 import { Args, parseArgs } from "./args.js";
-import { EsbuildOptions, buildOptions, watchOptions } from "./esbuild.js";
+import {
+  EsbuildOptions,
+  buildOptions,
+  watchOptions,
+  entryPointsDir,
+  findEntryPoints,
+} from "./esbuild.js";
 
 interface RunOptions {
   root?: string;
@@ -18,11 +25,13 @@ export const run = async function (options?: RunOptions): Promise<BuildContext |
 
   const args = parseArgs(argv);
 
-  // TODO: make nicer
-  let esbuildOptions = args.watch ? watchOptions(root, args) : buildOptions(root, args);
-  if (esbuildOptionsFn) {
-    esbuildOptions = esbuildOptionsFn(args, esbuildOptions);
-  }
+  const buildEsbuildOptions = (): EsbuildOptions => {
+    let esbuildOptions = args.watch ? watchOptions(root, args) : buildOptions(root, args);
+    if (esbuildOptionsFn) {
+      esbuildOptions = esbuildOptionsFn(args, esbuildOptions);
+    }
+    return esbuildOptions;
+  };
 
   const errorHandler = (err: any): void => {
     console.log(err);
@@ -32,13 +41,74 @@ export const run = async function (options?: RunOptions): Promise<BuildContext |
   if (args.watch) {
     touchManifest(root);
 
-    const ctx = await esbuild.context(esbuildOptions);
+    let ctx = await esbuild.context(buildEsbuildOptions());
     await ctx.watch().catch(errorHandler);
 
-    return ctx;
+    const sliceRoot = path.join(root, args.path);
+    let entryPointsKey = stringifyEntryPoints(findEntryPoints(sliceRoot));
+
+    // Watch the JS source dir so we can detect entry points added or removed after startup.
+    // esbuild's BuildContext is otherwise initialized with a fixed set of entry points and won't
+    // notice changes to it on its own.
+    const entryPointWatcher = chokidar.watch(entryPointsDir(sliceRoot), {
+      ignoreInitial: true,
+      persistent: true,
+    });
+
+    let restartQueue: Promise<void> = Promise.resolve();
+
+    // Replace the running esbuild context if the set of entry points has changed since last check.
+    // Serialize restarts through restartQueue so concurrent fs events can't race on
+    // dispose/recreate.
+    const handleEntryPointFsChange = (): void => {
+      restartQueue = restartQueue
+        .then(async () => {
+          const next = stringifyEntryPoints(findEntryPoints(sliceRoot));
+          if (next === entryPointsKey) return;
+
+          console.log("[hanami-esbuild] Entry points changed; restarting build...");
+          await ctx.dispose();
+          ctx = await esbuild.context(buildEsbuildOptions());
+          await ctx.watch();
+
+          // Only commit the new key once the restart fully succeeds; otherwise a transient failure
+          // would mask the change and prevent later events from retrying.
+          entryPointsKey = next;
+        })
+        .catch((err) => {
+          console.error("[hanami-esbuild] Error restarting build:", err);
+        });
+    };
+
+    entryPointWatcher.on("add", handleEntryPointFsChange);
+    entryPointWatcher.on("unlink", handleEntryPointFsChange);
+
+    // Returned context proxies through to the live esbuild context, but `dispose()` also tears
+    // down our entry-point watcher and waits for any in-flight restart to settle before disposing
+    // the (then current) context.
+    return new Proxy({} as BuildContext, {
+      get(_target, prop) {
+        if (prop === "dispose") {
+          return async (): Promise<void> => {
+            await entryPointWatcher.close();
+            await restartQueue;
+            await ctx.dispose();
+          };
+        }
+        const value = (ctx as any)[prop];
+        return typeof value === "function" ? value.bind(ctx) : value;
+      },
+    });
   } else {
-    await esbuild.build(esbuildOptions).catch(errorHandler);
+    await esbuild.build(buildEsbuildOptions()).catch(errorHandler);
   }
+};
+
+const stringifyEntryPoints = (entries: Record<string, string>): string => {
+  return Object.keys(entries)
+    .sort()
+    .map((key) => `${key}\0${entries[key]}`)
+    .join("\n");
 };
 
 const touchManifest = (root: string): void => {

--- a/test/hanami-assets.test.ts
+++ b/test/hanami-assets.test.ts
@@ -503,6 +503,69 @@ describe("hanami-assets", () => {
   );
 
   test(
+    "watch: detects a newly added entry point",
+    async () => {
+      const entryPoint = path.join(dest, "app/assets/js/app.js");
+      await fs.writeFile(entryPoint, "console.log('Hello, World!');");
+
+      const ctx = await assets.run({
+        root: dest,
+        argv: ["--path=app", "--dest=public/assets", "--watch"],
+      });
+
+      try {
+        await waitForManifest(dest, (m) => Boolean(m["app.js"]));
+
+        await fs.ensureDir(path.join(dest, "app/assets/js/admin"));
+        const newEntryPoint = path.join(dest, "app/assets/js/admin/app.js");
+        await fs.writeFile(newEntryPoint, "console.log('Hello, Admin!');");
+
+        await waitForManifest(dest, (m) => Boolean(m["admin/app.js"]));
+
+        const manifest = readManifest(dest);
+        expect(manifest["admin/app.js"]).toEqual({ url: "/assets/admin/app.js" });
+        expect(manifest["app.js"]).toBeDefined();
+
+        const newOutput = path.join(dest, "public/assets/admin/app.js");
+        expect(fs.existsSync(newOutput)).toBe(true);
+        expect(await fs.readFile(newOutput, "utf-8")).toMatch('console.log("Hello, Admin!");');
+      } finally {
+        await ctx!.dispose();
+      }
+    },
+    watchTimeout + 1000,
+  );
+
+  test(
+    "watch: detects a removed entry point",
+    async () => {
+      const mainEntry = path.join(dest, "app/assets/js/app.js");
+      await fs.writeFile(mainEntry, "console.log('main');");
+
+      await fs.ensureDir(path.join(dest, "app/assets/js/admin"));
+      const adminEntry = path.join(dest, "app/assets/js/admin/app.js");
+      await fs.writeFile(adminEntry, "console.log('admin');");
+
+      const ctx = await assets.run({
+        root: dest,
+        argv: ["--path=app", "--dest=public/assets", "--watch"],
+      });
+
+      try {
+        await waitForManifest(dest, (m) => Boolean(m["admin/app.js"]));
+
+        await fs.remove(adminEntry);
+
+        await waitForManifest(dest, (m) => !m["admin/app.js"]);
+        expect(readManifest(dest)["app.js"]).toBeDefined();
+      } finally {
+        await ctx!.dispose();
+      }
+    },
+    watchTimeout + 1000,
+  );
+
+  test(
     "watch: preserves esbuild outputs in the manifest when a static asset changes",
     async () => {
       const entryPoint = path.join(dest, "app/assets/js/app.js");


### PR DESCRIPTION
Until now, `assets watch` would build its entry point set once at startup and ignore any entry points later added or removed. Users would have to restart the watcher to pick up a new `app.{js,ts,...}` entry point.

To fix this, add a chokidar watcher on the JS source dir alongside the esbuild context. When the result of `findEntryPoints` changes, dispose the current context and start a new one with the updated set. Serialize restarts through a promise queue so rapid fs events can't race on dispose/recreate.

Resolves #39